### PR TITLE
Autosave drafts on Post new and edit forms

### DIFF
--- a/app/javascript/controllers/auto_save_controller.js
+++ b/app/javascript/controllers/auto_save_controller.js
@@ -1,0 +1,46 @@
+// Based on https://stevepolito.design/blog/rails-auto-save-form-data/
+import { Controller } from "@hotwired/stimulus";
+
+const notTheTokenField = ([field]) => field !== "authenticity_token";
+const notAFileField = ([_, value]) => !(value instanceof File);
+
+export default class extends Controller {
+  static targets = ["form"];
+
+  connect() {
+    this.localStorageKey = window.location;
+    this.setFormData();
+  }
+
+  clearLocalStorage() {
+    if (!localStorage.getItem(this.localStorageKey)) return;
+    localStorage.removeItem(this.localStorageKey);
+  }
+
+  getFormData() {
+    const form = new FormData(this.formTarget);
+    const data = Array.from(form.entries())
+      .filter(notTheTokenField)
+      .filter(notAFileField)
+      .map(([field, value]) => [field, value]);
+    return Object.fromEntries(data);
+  }
+
+  saveToLocalStorage() {
+    const data = this.getFormData();
+    localStorage.setItem(this.localStorageKey, JSON.stringify(data));
+  }
+
+  setFormData() {
+    const storage = localStorage.getItem(this.localStorageKey);
+    if (!storage) return;
+
+    const data = JSON.parse(storage);
+    const form = this.formTarget;
+
+    Object.entries(data).forEach(([name, value]) => {
+      const input = form.querySelector(`[name='${name}']`);
+      input && (input.value = value);
+    });
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,38 +4,41 @@
 
 import { application } from "./application";
 
-import GovukAccordionController from "./govuk_accordion_controller.js";
+import AutoSaveController from "./auto_save_controller";
+application.register("auto-save", AutoSaveController);
+
+import GovukAccordionController from "./govuk_accordion_controller";
 application.register("govuk-accordion", GovukAccordionController);
 
-import GovukButtonController from "./govuk_button_controller.js";
+import GovukButtonController from "./govuk_button_controller";
 application.register("govuk-button", GovukButtonController);
 
-import GovukCharacterCountController from "./govuk_character_count_controller.js";
+import GovukCharacterCountController from "./govuk_character_count_controller";
 application.register("govuk-character-count", GovukCharacterCountController);
 
-import GovukCheckboxesController from "./govuk_checkboxes_controller.js";
+import GovukCheckboxesController from "./govuk_checkboxes_controller";
 application.register("govuk-checkboxes", GovukCheckboxesController);
 
-import GovukDetailsController from "./govuk_details_controller.js";
+import GovukDetailsController from "./govuk_details_controller";
 application.register("govuk-details", GovukDetailsController);
 
-import GovukErrorSummaryController from "./govuk_error_summary_controller.js";
+import GovukErrorSummaryController from "./govuk_error_summary_controller";
 application.register("govuk-error-summary", GovukErrorSummaryController);
 
-import GovukHeaderController from "./govuk_header_controller.js";
+import GovukHeaderController from "./govuk_header_controller";
 application.register("govuk-header", GovukHeaderController);
 
-import GovukNotificationBannerController from "./govuk_notification_banner_controller.js";
+import GovukNotificationBannerController from "./govuk_notification_banner_controller";
 application.register(
   "govuk-notification-banner",
   GovukNotificationBannerController
 );
 
-import GovukRadiosController from "./govuk_radios_controller.js";
+import GovukRadiosController from "./govuk_radios_controller";
 application.register("govuk-radios", GovukRadiosController);
 
-import GovukSkipLinkController from "./govuk_skip_link_controller.js";
+import GovukSkipLinkController from "./govuk_skip_link_controller";
 application.register("govuk-skip-link", GovukSkipLinkController);
 
-import GovukTabsController from "./govuk_tabs_controller.js";
+import GovukTabsController from "./govuk_tabs_controller";
 application.register("govuk-tabs", GovukTabsController);

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,8 @@
-<%= form_with(model: [project, post]) do |f| %>
+<%= form_with(model: [project, post], data: {
+  module: "auto-save",
+  auto_save_target: "form",
+  action: "change->auto-save#saveToLocalStorage
+         \ submit->auto-save#clearLocalStorage" }) do |f| %>
   <%= govuk_row do %>
     <%= govuk_two_thirds do %>
       <%= f.govuk_error_summary %>


### PR DESCRIPTION
This implements a Stimulus controller that automatically saves the content of a form to localStorage, and reinstantiates it should the user navigate away and come back.

When the user submits the form, the local storage is cleared.

Based on https://stevepolito.design/blog/rails-auto-save-form-data/.