### PR TITLE
Tweaks to sign up and sign in

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,6 @@
-<h2>Change your password</h2>
+<% title = "Change your password" %>
+<%= content_for :page_title, title %>
+<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,6 @@
-<h2>Forgot your password?</h2>
+<% title = "Forgot your password?" %>
+<%= content_for :page_title, title %>
+<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>
@@ -8,11 +10,12 @@
                  data: { turbo: false }) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= f.govuk_email_field :email,
+        label: { text: "Email address" },
+        autofocus: true,
+        autocomplete: "email" %>
 
-      <%= f.govuk_submit "Send me reset password instructions" %>
+      <%= f.govuk_submit "Reset password" %>
     <% end %>
   <% end %>
 <% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,5 @@
 <% title = "Forgot your password?" %>
 <%= content_for :page_title, title %>
-<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>
@@ -9,6 +8,7 @@
                  html: { method: :post },
                  data: { turbo: false }) do |f| %>
       <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l"><%= title %></h1>
 
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,12 +1,12 @@
 <% title = "Create a design history account" %>
 <%= content_for :page_title, title %>
-<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>
     <%= form_for(resource, as: resource_name,
       url: registration_path(resource_name), data: { turbo: false }) do |f| %>
       <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l"><%= title %></h1>
 
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,6 @@
-<h2>Sign up</h2>
+<% title = "Create a design history account" %>
+<%= content_for :page_title, title %>
+<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>
@@ -17,9 +19,12 @@
       <%= f.govuk_password_field :password_confirmation,
         autocomplete: "new-password", label: { text: "Confirm password" } %>
 
-      <%= f.govuk_submit "Sign up" %>
+      <%= f.govuk_submit "Create account" %>
     <% end %>
   <% end %>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<p>
+  If you already have an account you can
+  <%= govuk_link_to "sign in", new_session_path(resource_name) %>.
+</p>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -12,7 +12,7 @@
         autocomplete: "email" %>
 
       <%= f.govuk_password_field :password, autocomplete: "new-password",
-        hint: { text: "#{@minimum_password_length} characters mininum"} %>
+        hint: { text: "#{@minimum_password_length} characters minimum"} %>
 
       <%= f.govuk_password_field :password_confirmation,
         autocomplete: "new-password", label: { text: "Confirm password" } %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,10 @@
       url: registration_path(resource_name), data: { turbo: false }) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= f.govuk_email_field :email,
+        label: { text: "Email address" },
+        autofocus: true,
+        autocomplete: "email" %>
 
       <%= f.govuk_password_field :password, autocomplete: "new-password",
         hint: { text: "#{@minimum_password_length} characters mininum"} %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,6 @@
-<h2>Sign in</h2>
+<% title = "Sign in" %>
+<%= content_for :page_title, title %>
+<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,5 @@
 <% title = "Sign in" %>
 <%= content_for :page_title, title %>
-<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>
@@ -8,6 +7,7 @@
                  url: session_path(resource_name),
                  data: { turbo: false }) do |f| %>
       <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l"><%= title %></h1>
 
       <%= f.govuk_email_field :email,
         label: { text: "Email address" },

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Log in</h2>
+<h2>Sign in</h2>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>
@@ -18,7 +18,7 @@
           label: { text: "Remember me" } %>
       <% end %>
 
-      <%= f.govuk_submit "Log in" %>
+      <%= f.govuk_submit "Sign in" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,7 +7,10 @@
                  data: { turbo: false }) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= f.govuk_email_field :email,
+        label: { text: "Email address" },
+        autofocus: true,
+        autocomplete: "email" %>
 
       <%= f.govuk_password_field :password, autocomplete: "current-password" %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,27 @@
-<%- if controller_name != 'sessions' %>
-  <%= govuk_link_to "Sign in", new_session_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= govuk_link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= govuk_link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= govuk_link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= govuk_link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= govuk_link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+<p>
+  <%- if controller_name != 'sessions' %>
+    <%= govuk_link_to "Sign in", new_session_path(resource_name) %><br />
   <% end %>
-<% end %>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= govuk_link_to "Create a design history account", new_registration_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <%= govuk_link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= govuk_link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <%= govuk_link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <% end %>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= govuk_link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <% end %>
+  <% end %>
+</p>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= govuk_link_to "Log in", new_session_path(resource_name) %><br />
+  <%= govuk_link_to "Sign in", new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,15 +1,23 @@
 <% content_for :masthead do %>
+  <% description = capture do %>
+    <p class="govuk-body-l">
+      Document and share design decisions. Create a record of how your service
+      has developed over time.
+    </p>
+
+    <%= govuk_start_button text: "Start now", href: projects_path %>
+  <% end %>
+
   <%= render(XGovukMastheadComponent.new(
-    classes: 'x-govuk-masthead--large',
+    classes: 'x-govuk-masthead--large govuk-!-padding-top-4 govuk-!-padding-bottom-2',
     title: { text: "Keep a design history" },
-    description: { text: "Document and share design decisions. Create a record
-                   \ of how your service has developed over time." }
+    description: { html: description }
   )) %>
 <% end %>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>
-    <h2>What is a design history</h2>
+    <h2 class="govuk-heading-m">What is a design history</h2>
 
     <p>A design history is like a blog. It features posts that describe the
     development of new features, iterations of existing ones, or findings from
@@ -19,9 +27,7 @@
     <p>Over time, a design history becomes a record of your designs. It tells
     the story of what you designed and why.</p>
 
-    <%= govuk_start_button text: "Start now", href: projects_path %>
-
-    <h2>Why you should keep a design history</h2>
+    <h2 class="govuk-heading-m">Why you should keep a design history</h2>
 
     <p>Keeping a design history makes it easy to know why a service is the way
     it is.</p>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -5,11 +5,17 @@
       has developed over time.
     </p>
 
-    <%= govuk_start_button text: "Start now", href: projects_path %>
+    <div class="govuk-button-group govuk-!-margin-bottom-0">
+      <%= govuk_start_button text: "Start now", href: new_user_registration_path %>
+      <p>or</p>
+      <p class="govuk-!-padding-left-2 govuk-!-margin-bottom-0">
+        <%= govuk_link_to "Sign in", new_user_session_path, text_colour: true, class: 'govuk-!-font-weight-bold' %>
+      </p>
+    </div>
   <% end %>
 
   <%= render(XGovukMastheadComponent.new(
-    classes: 'x-govuk-masthead--large govuk-!-padding-top-4 govuk-!-padding-bottom-2',
+    classes: 'x-govuk-masthead--large govuk-!-padding-top-4',
     title: { text: "Keep a design history" },
     description: { html: description }
   )) %>

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -2,6 +2,18 @@ en:
   activerecord:
     errors:
       models:
+        user:
+          attributes:
+            email:
+              invalid: Enter an email address in the correct format, like name@example.com
+              blank: Enter an email address
+              taken: An account already exists with this email address
+              not_found: Email address not found
+            password:
+              blank: Enter a password
+              too_short: Enter a longer password (minimum is %{count} characters)
+            password_confirmation:
+              confirmation: Passwords do not match
         project:
           attributes:
             title:


### PR DESCRIPTION
- Bring start page inline with prototype
- Create an account, not Sign up
- "Email address" label field
- Add missing page titles
- Adds friendlier error messages
- Show error summary before page title

![localhost_3000_ (3)](https://user-images.githubusercontent.com/319055/198740690-ce5d0657-daab-4102-b138-daea5bdacda4.png)

![localhost_3000_ (1)](https://user-images.githubusercontent.com/319055/198740692-06e82606-f050-4727-bcc6-b733a03dca3f.png)

![localhost_3000_](https://user-images.githubusercontent.com/319055/198740614-4c5a0368-e022-4b0a-b8b3-dc7b4c383d6a.png)

