### PR TITLE
Basic subdomain support

### DIFF
--- a/app/controllers/app_controller.rb
+++ b/app/controllers/app_controller.rb
@@ -1,0 +1,17 @@
+class AppController < ApplicationController
+  before_action :set_project
+
+  def index
+    @posts = @project.posts.where(published: true).order(published_at: :desc)
+  end
+
+  def show
+    @post = @project.posts.find(params[:post_id])
+  end
+
+  private
+
+  def set_project
+    @project = Project.find_by(subdomain: request.subdomain)
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,8 +1,4 @@
 class PagesController < ApplicationController
   def start
   end
-
-  def working
-    @subdomain = request.subdomain
-  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -23,6 +23,13 @@ class Project < ApplicationRecord
   has_many :posts, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 255 }
-  validates :subdomain, presence: true, length: { maximum: 50 }
+  validates :subdomain,
+            presence: true,
+            length: {
+              maximum: 50
+            },
+            exclusion: {
+              in: %w[www the our]
+            }
   validates :description, presence: true, length: { maximum: 255 }
 end

--- a/app/views/app/index.html.erb
+++ b/app/views/app/index.html.erb
@@ -1,0 +1,25 @@
+<h1 class="govuk-heading-l govuk-!-margin-bottom-8"><%= @project.title %></h1>
+
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <ol class="app-document-list app-document-list--large">
+      <% @posts.each do |post| %>
+        <li class="app-document-list__item">
+          <%= govuk_link_to app_post_path(post.id) do %>
+            <h2 class="app-document-list__item-title">
+              <%= post.title %>
+            </h2>
+          <% end %>
+          <ul class="app-document-list__item-metadata">
+            <li class="app-document-list__attribute">
+              <time
+                class="app-document-list__attribute"
+                datetime="<%= post.updated_at.iso8601 %>">
+                <%= post.published_at.strftime("%d %B %Y") %></time>
+            </li>
+          </ul>
+        </li>
+      <% end %>
+    </ol>
+  <% end %>
+<% end %>

--- a/app/views/app/show.html.erb
+++ b/app/views/app/show.html.erb
@@ -1,0 +1,34 @@
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: {
+    @project.title => app_posts_path,
+    @post.title => nil
+  }) %>
+<% end %>
+
+<%= govuk_row do %>
+  <div class="govuk-grid-column-full">
+    <header class="app-document-header">
+      <h1 class="app-document-header__title govuk-heading-xl">
+        <%= @post.title %>
+      </h1>
+    </header>
+
+    <footer>
+      <p class="app-metadata">
+        <span class="govuk-visually-hidden">Posted on: </span>
+        <time datetime="<%= @post.updated_at.iso8601 %>">
+          <%= @post.published_at.strftime("%d %B %Y") %>
+        </time>
+      </p>
+    </footer>
+  </div>
+
+  <%= govuk_two_thirds do %>
+    <%= GovukMarkdown.render(@post.body).html_safe %>
+
+    <% @post.images.each do |image| %>
+      <%= image_tag image,
+        style: 'max-width: 100%; outline: 1px solid rgba(177, 180, 182, 0.5' %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -6,10 +6,13 @@
     </p>
 
     <div class="govuk-button-group govuk-!-margin-bottom-0">
-      <%= govuk_start_button text: "Start now", href: new_user_registration_path %>
+      <%= govuk_start_button text: "Start now",
+        href: current_user ? projects_path : new_user_registration_path %>
       <p>or</p>
       <p class="govuk-!-padding-left-2 govuk-!-margin-bottom-0">
-        <%= govuk_link_to "Sign in", new_user_session_path, text_colour: true, class: 'govuk-!-font-weight-bold' %>
+      <%= govuk_link_to "Sign in",
+        current_user ? projects_path : new_user_session_path,
+        text_colour: true, class: 'govuk-!-font-weight-bold' %>
       </p>
     </div>
   <% end %>

--- a/app/views/pages/working.html.erb
+++ b/app/views/pages/working.html.erb
@@ -1,5 +1,0 @@
-<% if @subdomain.empty? %>
-  <p>The custom app domain is working, but you didn't specify a subdomain.</p>
-<% else %>
-  <p>The current subdomain is: <code><%= @subdomain %></code></p>
-<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,6 +63,8 @@ Rails.application.configure do
   # Required by devise
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+  config.main_domain = "localhost"
+
   config.hosts << "app.local"
   config.app_domain = "app.local"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,6 +80,8 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.hosts << "designhistory.io"
+  config.main_domain = "designhistory.io"
+
   config.hosts << "designhistory.app"
   config.app_domain = "designhistory.app"
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,6 +51,8 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  config.main_domain = "localhost"
+
   config.hosts << "app.local"
   config.app_domain = "app.local"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,16 @@
 Rails.application.routes.draw do
-  root to: "pages#start"
+  constraints domain: "localhost" do
+    root to: "pages#start"
 
-  devise_for :users
+    devise_for :users
 
-  resources :projects do
-    resources :posts
+    resources :projects do
+      resources :posts
+    end
   end
 
   constraints domain: Rails.application.config.app_domain do
-    get "/test", to: "pages#working"
+    get "/", to: "pages#working"
   end
 
   scope via: :all do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,8 @@ Rails.application.routes.draw do
   end
 
   constraints domain: Rails.application.config.app_domain do
-    get "/", to: "pages#working"
+    get "/", to: "app#index", as: "app_posts"
+    get "/:post_id", to: "app#show", as: "app_post"
   end
 
   scope via: :all do


### PR DESCRIPTION
This adds a new controller for `designhistory.app` related routes, and namespaces the devise/other ones for the .io main domain. The index/show views still need to be customised to the latest version in the prototype, which is coming up as a follow-up.