### PR TITLE
Allow arbitrary subdomains on admin and app domain 

### DIFF
--- a/app/controllers/app_controller.rb
+++ b/app/controllers/app_controller.rb
@@ -12,6 +12,6 @@ class AppController < ApplicationController
   private
 
   def set_project
-    @project = Project.find_by(subdomain: request.subdomain)
+    @project = Project.find_by!(subdomain: request.subdomain)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,8 +65,7 @@ Rails.application.configure do
 
   config.admin_domain = "localhost"
 
-  config.hosts << "app.local"
   config.app_domain = "app.local"
-
-  config.hosts << "this.app.local"
+  config.hosts << "app.local"
+  config.hosts << ".app.local"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   # Required by devise
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
-  config.main_domain = "localhost"
+  config.admin_domain = "localhost"
 
   config.hosts << "app.local"
   config.app_domain = "app.local"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,11 +79,11 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.hosts << "designhistory.io"
   config.admin_domain = "designhistory.io"
+  config.hosts << "designhistory.io"
+  config.hosts << ".designhistory.io"
 
-  config.hosts << "designhistory.app"
   config.app_domain = "designhistory.app"
-
-  config.hosts << "this.designhistory.app" # TODO: Make this database-driven
+  config.hosts << "designhistory.app"
+  config.hosts << ".designhistory.app"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.hosts << "designhistory.io"
-  config.main_domain = "designhistory.io"
+  config.admin_domain = "designhistory.io"
 
   config.hosts << "designhistory.app"
   config.app_domain = "designhistory.app"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,8 +53,7 @@ Rails.application.configure do
 
   config.admin_domain = "localhost"
 
-  config.hosts << "app.local"
   config.app_domain = "app.local"
-
-  config.hosts << "this.app.local"
+  config.hosts << "app.local"
+  config.hosts << ".app.local"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  config.main_domain = "localhost"
+  config.admin_domain = "localhost"
 
   config.hosts << "app.local"
   config.app_domain = "app.local"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  constraints domain: Rails.application.config.main_domain do
+  constraints domain: Rails.application.config.admin_domain do
     root to: "pages#start"
 
     devise_for :users


### PR DESCRIPTION
Prefixing the domain with . means to allow all subdomains, and is more robust than driving this by the database.

[Rename main_domain to admin_domain](https://github.com/design-history/design-history/commit/a792e75b05b57ec25988c5c5b8f803974ef02eb7).

[Use find_by! for subdomain project lookup](https://github.com/design-history/design-history/commit/5a18fc0b1d2140fb969c39918c8bea334a8fa6a4). This allows the app to return a 404 if the matching project isn't found.