### PR TITLE
Give errors precedence in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
+  scope via: :all do
+    get "/404", to: "errors#not_found"
+    get "/422", to: "errors#unprocessable_entity"
+    get "/429", to: "errors#too_many_requests"
+    get "/500", to: "errors#internal_server_error"
+  end
+
   constraints domain: Rails.application.config.admin_domain do
     root to: "pages#start"
 
@@ -12,12 +19,5 @@ Rails.application.routes.draw do
   constraints domain: Rails.application.config.app_domain do
     get "/", to: "app#index", as: "app_posts"
     get "/:post_id", to: "app#show", as: "app_post"
-  end
-
-  scope via: :all do
-    get "/404", to: "errors#not_found"
-    get "/422", to: "errors#unprocessable_entity"
-    get "/429", to: "errors#too_many_requests"
-    get "/500", to: "errors#internal_server_error"
   end
 end


### PR DESCRIPTION
This fixes an error where attempting to access `something.designhistory.app` would result in a 404, but then the `/404` route would be hijacked by the `/:post_id` app route, which would lead to a 500.