### PR TITLE
Display uploaded images when editing posts

### DIFF
--- a/app/assets/stylesheets/_upload-screenshots.scss
+++ b/app/assets/stylesheets/_upload-screenshots.scss
@@ -1,9 +1,0 @@
-.app-upload-screenshots {
-  background-color: govuk-tint($app-brand-colour, 80%);
-  border: 2px dashed $app-button-colour;
-  max-height: 1000px;
-  min-height: 500px;
-  overflow-y: scroll;
-  padding: govuk-spacing(4);
-  position: relative;
-}

--- a/app/assets/stylesheets/_upload.scss
+++ b/app/assets/stylesheets/_upload.scss
@@ -1,0 +1,9 @@
+.app-upload {
+  input {
+    background-color: govuk-tint($app-brand-colour, 80%);
+    box-sizing: border-box;
+    border: 2px dashed $app-button-colour;
+    padding: govuk-spacing(4);
+    width: 100%;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,9 +19,9 @@ $app-tint-colour: govuk-tint($app-masthead-colour, 50%);
 @import "footer";
 @import "global";
 @import "header";
-@import "upload-screenshots";
 @import "masthead";
 @import "posts";
+@import "upload";
 
 .app-design-history {
   background-color: $app-tint-colour;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,7 +36,8 @@ class PostsController < ApplicationController
   # PATCH/PUT /posts/1
   def update
     if @post.update(post_params)
-      redirect_to [@project, @post], notice: "Post was successfully updated"
+      redirect_to edit_project_post_path(@project, @post),
+                  notice: "Post was successfully updated"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -6,16 +6,28 @@
   <%= govuk_row do %>
     <%= govuk_two_thirds do %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_field :title %>
-      <%= f.govuk_text_field :slug %>
-      <%= f.govuk_text_area :body, rows: 14 %>
+      <%= f.govuk_text_field :title,
+        label: { text: 'Title', size: 's' },
+        hint: { text: 'Good titles describe the post, do not use ‘User
+                research’ or ‘MVP’',
+                class: 'govuk-hint govuk-!-font-size-16' } %>
+      <%= f.govuk_text_field :slug,
+        label: { text: 'Slug', size: 's' },
+        hint: { text: '[Coming soon] A user-friendly URL, for example
+                how-we-chose-our-service-name',
+                class: 'govuk-hint govuk-!-font-size-16' } %>
+      <%= f.govuk_text_area :body, rows: 20,
+        label: { text: 'Post', size: 's' },
+        hint: { text: 'Use markdown for links, headings and images',
+                class: 'govuk-hint govuk-!-font-size-16' } %>
       <%= f.govuk_check_boxes_fieldset :published, multiple: false,
         legend: { text: 'Publish', size: 'm' } do %>
         <%= f.govuk_check_box :published, 1, 0,
           multiple: false,
           label: { text: "Published" } %>
       <% end %>
-      <%= f.govuk_date_field :published_at, legend: { text: 'Published date' } %>
+      <%= f.govuk_date_field :published_at,
+        legend: { text: 'Published date' } %>
     <% end %>
 
     <%= govuk_one_third do %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -31,9 +31,29 @@
     <% end %>
 
     <%= govuk_one_third do %>
-      <%= f.file_field :images,
-        class: "app-upload-screenshots",
-        multiple: true, accept: 'image/png,image/jpeg,image/gif' %>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+        Images
+      </h2>
+
+      <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-2">
+        Shown at the bottom of a post
+      </p>
+
+      <div class="app-upload">
+        <% post.images.each do |image| %>
+          <%= image_tag image,
+            class: 'govuk-!-margin-bottom-2',
+            style: 'max-width: 100%; border: 1px solid #000' %>
+        <% end %>
+
+        <%= f.label :images, "Add more images",
+          class: 'govuk-label govuk-label--s govuk-!-margin-top-2
+                  govuk-!-margin-bottom-2' %>
+        <%= f.file_field :images,
+          multiple: true, accept: 'image/png,image/jpeg,image/gif' %>
+
+        <%= f.govuk_submit "Save images", class: 'govuk-!-margin-top-4' %>
+      </div>
     <% end %>
 
   <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -10,7 +10,19 @@
 <%= content_for :page_title, title %>
 <h1 class="govuk-heading-xl"><%= title %></h1>
 
-<%= render "form", project: @project, post: @post %>
+<div class="govuk-tabs">
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+      <a class="govuk-tabs__tab"
+        href="<%= edit_project_post_path(@project, @post) %>">
+        Write
+      </a>
+    </li>
+  </ul>
+  <div class="govuk-tabs__panel">
+    <%= render "form", project: @project, post: @post %>
+  </div>
+</div>
 
 <div>
   <%= govuk_link_to "Show this post", [@project, @post] %> |

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -23,7 +23,7 @@
             <% unless post.published? %>
               <%= govuk_tag(text: 'Draft', colour: 'grey') %>
             <% end %>
-            <%= govuk_link_to [@project, post] do %>
+            <%= govuk_link_to edit_project_post_path(@project, post) do %>
               <%= post.title %>
             <% end %>
           </h2>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module DesignHistory
     )
 
     config.exceptions_app = routes
+
+    config.active_storage.replace_on_assign_to_many = false
   end
 end


### PR DESCRIPTION
### Before

![image](https://user-images.githubusercontent.com/1650875/201547740-80e532d1-9f07-4a4f-a589-518ce8055921.png)

### After

![image](https://user-images.githubusercontent.com/1650875/201547706-5737d983-e119-45cf-b5bf-a651fcce15a3.png)

### Summary

See commits for more details:

- Link to posts edit directly from index
- Don't replace existing images when adding new ones
- Use tabs on the edit post page
- Customise form labels on post edit page
- Display uploaded images when editing posts
- Redirect to edit post after editing a post

The design is different from the prototype; this is the no-JS version that will progressively enhance into the full green dropzone one from the prototype, and combine that with Ajax upload.

What's pretty high priority now is reordering/removing images, and the alt text/caption editor.