### PR TITLE
Fix some more buttons

### DIFF
--- a/app/assets/stylesheets/_button.scss
+++ b/app/assets/stylesheets/_button.scss
@@ -6,10 +6,17 @@ $app-button-shadow-colour: govuk-shade($app-button-colour, 60%);
 .app-button {
   background-color: $app-button-colour;
   box-shadow: 0 $govuk-border-width-form-element 0 $app-button-shadow-colour;
+  &:hover {
+    background-color: $app-button-hover-colour;
+  }
 }
 
-.app-button:hover {
-  background-color: $app-button-hover-colour;
+.govuk-button.govuk-button--start {
+  background-color: $app-button-colour;
+  box-shadow: 0 $govuk-border-width-form-element 0 $app-button-shadow-colour;
+  &:hover {
+    background-color: $app-button-hover-colour;
+  }
 }
 
 // Inverse button

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -12,7 +12,8 @@
   <%= govuk_link_to "Change details", edit_project_path(@project) %>
 </p>
 
-<%= govuk_button_link_to "New post", new_project_post_path(@project) %>
+<%= govuk_button_link_to "New post", new_project_post_path(@project),
+  class: 'app-button' %>
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -31,7 +31,7 @@
       %>
 
       <%= f.govuk_submit editing ? "Save changes" : "Create design history",
-        class: 'app-submit' %>
+        class: 'app-button' %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -18,7 +18,8 @@
     <% end %>
 
     <p>
-      <%= govuk_button_link_to "New design history", new_project_path %>
+      <%= govuk_button_link_to "New design history", new_project_path,
+        class: 'app-button' %>
     </p>
   <% end %>
 <% end %>


### PR DESCRIPTION
The previous CSS refactor from overriding `govuk-button` to creating new `app-button` styles left out a few buttons.

I had to override `govuk-button--start` stlyes because our helper doesn't allow customising classes. Tech debt.