### PR TITLE
Add buttons to reorder post images

### DIFF
--- a/app/assets/stylesheets/_upload.scss
+++ b/app/assets/stylesheets/_upload.scss
@@ -10,10 +10,22 @@
   &__attachment {
     position: relative;
 
-    button {
+    &-buttons {
+      background: #000;
+      border: 1px solid #000;
+      margin-right: 0;
       position: absolute;
       right: -1px;
       top: 0;
+
+      .govuk-button {
+        margin-bottom: 2px;
+        margin-right: 2px;
+      }
+
+      form:last-child .govuk-button {
+        margin-right: 0;
+      }
     }
   }
 }

--- a/app/controllers/post_images_controller.rb
+++ b/app/controllers/post_images_controller.rb
@@ -1,0 +1,51 @@
+class PostImagesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_project
+  before_action :set_post
+  before_action :set_image, except: [:create]
+
+  def up
+    @post.ordered_image_move_up!(@image)
+    redirect_to edit_project_post_path(@project, @post),
+                notice: "Image was successfully moved"
+  end
+
+  def down
+    @post.ordered_image_move_down!(@image)
+    redirect_to edit_project_post_path(@project, @post),
+                notice: "Image was successfully moved"
+  end
+
+  def create
+    if @post.update(create_params)
+      redirect_to edit_project_post_path(@project, @post),
+                  notice: "Images were successfully uploaded"
+    else
+      render "post/edit", status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @image.purge
+    redirect_to edit_project_post_path(@project, @post),
+                notice: "Image was successfully deleted"
+  end
+
+  private
+
+  def create_params
+    params.require(:post).permit(images: [])
+  end
+
+  def set_project
+    @project = current_user.projects.find(params[:project_id])
+  end
+
+  def set_post
+    @post = @project.posts.with_attached_images.find(params[:post_id])
+  end
+
+  def set_image
+    @image = @post.images.find(params[:id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,10 +36,6 @@ class PostsController < ApplicationController
 
   # PATCH/PUT /posts/1
   def update
-    if destroy_attachment_params
-      @post.images.find(destroy_attachment_params).purge
-    end
-
     if @post.update(post_params)
       redirect_to edit_project_post_path(@project, @post),
                   notice: "Post was successfully updated"
@@ -70,14 +66,7 @@ class PostsController < ApplicationController
       :slug,
       :body,
       :published,
-      :published_at,
-      images: []
+      :published_at
     )
-  end
-
-  def destroy_attachment_params
-    return false if params[:destroy_attachment].blank?
-
-    params.require(:destroy_attachment)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -47,6 +47,14 @@ class Post < ApplicationRecord
     ordered_image_move!(image, :down)
   end
 
+  def first_image?(image)
+    ordered_images.index(image).zero?
+  end
+
+  def last_image?(image)
+    ordered_images.index(image) == ordered_images.size - 1
+  end
+
   private
 
   def ordered_image_move!(image, where)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,15 +2,16 @@
 #
 # Table name: posts
 #
-#  id           :bigint           not null, primary key
-#  body         :text
-#  published    :boolean
-#  published_at :date
-#  slug         :string
-#  title        :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  project_id   :bigint           not null
+#  id                :bigint           not null, primary key
+#  body              :text
+#  ordered_image_ids :json
+#  published         :boolean
+#  published_at      :date
+#  slug              :string
+#  title             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  project_id        :bigint           not null
 #
 # Indexes
 #

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -28,4 +28,14 @@ class Post < ApplicationRecord
   validates :slug, length: { maximum: 50 }
   validates :body, presence: true
   validates :published_at, presence: true, if: -> { published == true }
+
+  def ordered_images
+    images.sort_by do |image|
+      ordered_image_ids.index(image.id) || (image.id * 100)
+    end
+  end
+
+  def ordered_image_ids=(ids)
+    super(ids.map(&:to_i))
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -38,4 +38,37 @@ class Post < ApplicationRecord
   def ordered_image_ids=(ids)
     super(ids.map(&:to_i))
   end
+
+  def ordered_image_move_up!(image)
+    ordered_image_move!(image, :up)
+  end
+
+  def ordered_image_move_down!(image)
+    ordered_image_move!(image, :down)
+  end
+
+  private
+
+  def ordered_image_move!(image, where)
+    unless image.is_a?(ActiveStorage::Attachment)
+      raise TypeError "#{image} must be ActiveStorage::Attachment"
+    end
+
+    images = ordered_images.dup
+
+    case where
+    when :up
+      ArrayElementMove.up!(images, image)
+    when :down
+      ArrayElementMove.down!(images, image)
+    else
+      raise "Unknown option #{where}"
+    end
+
+    self.ordered_image_ids = images.map(&:id)
+    save!
+    reload
+
+    true
+  end
 end

--- a/app/views/app/show.html.erb
+++ b/app/views/app/show.html.erb
@@ -26,7 +26,7 @@
   <%= govuk_two_thirds do %>
     <%= GovukMarkdown.render(@post.body).html_safe %>
 
-    <% @post.images.each do |image| %>
+    <% @post.ordered_images.each do |image| %>
       <%= image_tag image,
         style: 'max-width: 100%; outline: 1px solid rgba(177, 180, 182, 0.5' %>
     <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,10 +1,10 @@
-<%= form_with(model: [project, post], data: {
-  module: "auto-save",
-  auto_save_target: "form",
-  action: "change->auto-save#saveToLocalStorage
-         \ submit->auto-save#clearLocalStorage" }) do |f| %>
-  <%= govuk_row do %>
-    <%= govuk_two_thirds do %>
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <%= form_with(model: [project, post], data: {
+      module: "auto-save",
+      auto_save_target: "form",
+      action: "change->auto-save#saveToLocalStorage
+             \ submit->auto-save#clearLocalStorage" }) do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :title,
         label: { text: 'Title', size: 's' },
@@ -28,36 +28,63 @@
       <% end %>
       <%= f.govuk_date_field :published_at,
         legend: { text: 'Published date' } %>
+
+      <%= f.govuk_submit "Save", class: 'app-button' %>
     <% end %>
+  <% end %>
 
-    <%= govuk_one_third do %>
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-        Images
-      </h2>
+  <%= govuk_one_third do %>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+      Images
+    </h2>
 
-      <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-2">
-        Shown at the bottom of a post
-      </p>
+    <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-2">
+      Shown at the bottom of a post
+    </p>
 
-      <div class="app-upload">
-        <div class="app-upload__attachments">
-          <% post.ordered_images.each do |image| %>
-            <div class="app-upload__attachment">
-              <%= image_tag image,
-                class: 'govuk-!-margin-bottom-2',
-                style: 'max-width: 100%; border: 1px solid #000' %>
+    <div class="app-upload">
+      <div class="app-upload__attachments">
+        <% post.ordered_images.each do |image| %>
+          <div class="app-upload__attachment">
+            <%= image_tag image,
+              class: 'govuk-!-margin-bottom-2',
+              style: 'max-width: 100%; border: 1px solid #000' %>
 
-              <%= f.button name: "destroy_attachment",
-                class: 'govuk-button govuk-!-font-weight-bold
-                  govuk-button--secondary',
-                value: image.id do %>
+            <div class="app-upload__attachment-buttons govuk-button-group">
+              <% unless @post.first_image?(image) %>
+                <%= button_to up_project_post_image_path(@project, @post, image),
+                  class: 'govuk-button govuk-button--secondary
+                          govuk-!-font-weight-bold' do %>
+                  ↑ <span class="govuk-visually-hidden">
+                    Move up image <%= image.id %></span>
+                <% end %>
+              <% end %>
+
+              <% unless @post.last_image?(image) %>
+                <%= button_to down_project_post_image_path(@project, @post, image),
+                  class: 'govuk-button govuk-button--secondary
+                          govuk-!-font-weight-bold' do %>
+                  ↓ <span class="govuk-visually-hidden">
+                    Move down image <%= image.id %></span>
+                <% end %>
+              <% end %>
+
+              <%= button_to project_post_image_path(@project, @post, image),
+                method: :delete,
+                class: 'govuk-button govuk-button--secondary
+                        govuk-!-font-weight-bold' do %>
                 × <span class="govuk-visually-hidden">
                   Delete image <%= image.id %></span>
               <% end %>
             </div>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
+      </div>
 
+      <%= form_with(model: @post,
+                    url: project_post_images_path(@project, @post),
+                    method: :post) do |f| %>
+        <%= f.govuk_error_summary %>
         <%= f.label :images, "Add more images",
           class: 'govuk-label govuk-label--s govuk-!-margin-top-2
                   govuk-!-margin-bottom-2' %>
@@ -66,9 +93,7 @@
 
         <%= f.govuk_submit "Save images",
           class: 'app-button govuk-!-margin-top-4' %>
-      </div>
-    <% end %>
-
+      <% end %>
+    </div>
   <% end %>
-  <%= f.govuk_submit "Save", class: 'app-button' %>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -41,7 +41,7 @@
 
       <div class="app-upload">
         <div class="app-upload__attachments">
-          <% post.images.each do |image| %>
+          <% post.ordered_images.each do |image| %>
             <div class="app-upload__attachment">
               <%= image_tag image,
                 class: 'govuk-!-margin-bottom-2',

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -42,58 +42,60 @@
       Shown at the bottom of a post
     </p>
 
-    <div class="app-upload">
-      <div class="app-upload__attachments">
-        <% post.ordered_images.each do |image| %>
-          <div class="app-upload__attachment">
-            <%= image_tag image,
-              class: 'govuk-!-margin-bottom-2',
-              style: 'max-width: 100%; border: 1px solid #000' %>
+    <%= turbo_frame_tag "images" do %>
+      <div class="app-upload">
+        <div class="app-upload__attachments">
+          <% post.ordered_images.each do |image| %>
+            <div class="app-upload__attachment">
+              <%= image_tag image,
+                class: 'govuk-!-margin-bottom-2',
+                style: 'max-width: 100%; border: 1px solid #000' %>
 
-            <div class="app-upload__attachment-buttons govuk-button-group">
-              <% unless @post.first_image?(image) %>
-                <%= button_to up_project_post_image_path(@project, @post, image),
+              <div class="app-upload__attachment-buttons govuk-button-group">
+                <% unless @post.first_image?(image) %>
+                  <%= button_to up_project_post_image_path(@project, @post, image),
+                    class: 'govuk-button govuk-button--secondary
+                            govuk-!-font-weight-bold' do %>
+                    ↑ <span class="govuk-visually-hidden">
+                      Move up image <%= image.id %></span>
+                  <% end %>
+                <% end %>
+
+                <% unless @post.last_image?(image) %>
+                  <%= button_to down_project_post_image_path(@project, @post, image),
+                    class: 'govuk-button govuk-button--secondary
+                            govuk-!-font-weight-bold' do %>
+                    ↓ <span class="govuk-visually-hidden">
+                      Move down image <%= image.id %></span>
+                  <% end %>
+                <% end %>
+
+                <%= button_to project_post_image_path(@project, @post, image),
+                  method: :delete,
                   class: 'govuk-button govuk-button--secondary
                           govuk-!-font-weight-bold' do %>
-                  ↑ <span class="govuk-visually-hidden">
-                    Move up image <%= image.id %></span>
+                  × <span class="govuk-visually-hidden">
+                    Delete image <%= image.id %></span>
                 <% end %>
-              <% end %>
-
-              <% unless @post.last_image?(image) %>
-                <%= button_to down_project_post_image_path(@project, @post, image),
-                  class: 'govuk-button govuk-button--secondary
-                          govuk-!-font-weight-bold' do %>
-                  ↓ <span class="govuk-visually-hidden">
-                    Move down image <%= image.id %></span>
-                <% end %>
-              <% end %>
-
-              <%= button_to project_post_image_path(@project, @post, image),
-                method: :delete,
-                class: 'govuk-button govuk-button--secondary
-                        govuk-!-font-weight-bold' do %>
-                × <span class="govuk-visually-hidden">
-                  Delete image <%= image.id %></span>
-              <% end %>
+              </div>
             </div>
-          </div>
+          <% end %>
+        </div>
+
+        <%= form_with(model: @post,
+                      url: project_post_images_path(@project, @post),
+                      method: :post) do |f| %>
+          <%= f.govuk_error_summary %>
+          <%= f.label :images, "Add more images",
+            class: 'govuk-label govuk-label--s govuk-!-margin-top-2
+                    govuk-!-margin-bottom-2' %>
+          <%= f.file_field :images,
+            multiple: true, accept: 'image/png,image/jpeg,image/gif' %>
+
+          <%= f.govuk_submit "Save images",
+            class: 'app-button govuk-!-margin-top-4' %>
         <% end %>
       </div>
-
-      <%= form_with(model: @post,
-                    url: project_post_images_path(@project, @post),
-                    method: :post) do |f| %>
-        <%= f.govuk_error_summary %>
-        <%= f.label :images, "Add more images",
-          class: 'govuk-label govuk-label--s govuk-!-margin-top-2
-                  govuk-!-margin-bottom-2' %>
-        <%= f.file_field :images,
-          multiple: true, accept: 'image/png,image/jpeg,image/gif' %>
-
-        <%= f.govuk_submit "Save images",
-          class: 'app-button govuk-!-margin-top-4' %>
-      <% end %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,7 +27,7 @@
   <%= govuk_two_thirds do %>
     <%= GovukMarkdown.render(@post.body).html_safe %>
 
-    <% @post.images.each do |image| %>
+    <% @post.ordered_images.each do |image| %>
       <%= image_tag image,
         style: 'max-width: 100%; outline: 1px solid rgba(177, 180, 182, 0.5)' %>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,8 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "rails/test_unit/railtie"
 
+require "./lib/array_element_move"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,14 @@ Rails.application.routes.draw do
     devise_for :users
 
     resources :projects do
-      resources :posts
+      resources :posts do
+        resources :images,
+                  only: %i[create destroy],
+                  controller: "post_images" do
+          post :up, on: :member
+          post :down, on: :member
+        end
+      end
     end
   end
 

--- a/db/migrate/20221116180342_add_ordered_image_ids_to_posts.rb
+++ b/db/migrate/20221116180342_add_ordered_image_ids_to_posts.rb
@@ -1,0 +1,5 @@
+class AddOrderedImageIdsToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :posts, :ordered_image_ids, :json, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_11_092302) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_16_180342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_11_092302) do
     t.date "published_at"
     t.bigint "project_id", null: false
     t.string "slug"
+    t.json "ordered_image_ids", default: []
     t.index ["project_id"], name: "index_posts_on_project_id"
   end
 

--- a/lib/array_element_move.rb
+++ b/lib/array_element_move.rb
@@ -1,0 +1,22 @@
+module ArrayElementMove
+  MustBeUniqArray = Class.new(StandardError)
+  ItemNotInArray = Class.new(StandardError)
+
+  def self.up!(array, item)
+    check_if_uniq!(array)
+    return array if array.first == item
+    position = array.index(item) || raise(ItemNotInArray)
+    array.insert((position - 1), array.delete_at(position))
+  end
+
+  def self.down!(array, item)
+    check_if_uniq!(array)
+    return array if array.last == item
+    position = array.index(item) || raise(ItemNotInArray)
+    array.insert((position + 1), array.delete_at(position))
+  end
+
+  def self.check_if_uniq!(array)
+    raise MustBeUniqArray if array.size != array.uniq.size
+  end
+end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -2,15 +2,16 @@
 #
 # Table name: posts
 #
-#  id           :bigint           not null, primary key
-#  body         :text
-#  published    :boolean
-#  published_at :date
-#  slug         :string
-#  title        :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  project_id   :bigint           not null
+#  id                :bigint           not null, primary key
+#  body              :text
+#  ordered_image_ids :json
+#  published         :boolean
+#  published_at      :date
+#  slug              :string
+#  title             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  project_id        :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
Best reviewed commit by commit and ignoring whitespace.

Also use a turbo frame to handle image uploads, deletion, and reordering, which honestly feels like magic.

![image](https://user-images.githubusercontent.com/1650875/202329952-1ad81951-a1bf-4fb1-bf7e-47e8078cdd99.png)
