### PR TITLE
Fix post creation

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -28,7 +28,8 @@ class PostsController < ApplicationController
     @post = @project.posts.new(post_params)
 
     if @post.save
-      redirect_to [@project, @post], notice: "Post was successfully created"
+      redirect_to edit_project_post_path(@project, @post),
+                  notice: "Post was successfully created"
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -33,69 +33,71 @@
     <% end %>
   <% end %>
 
-  <%= govuk_one_third do %>
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-      Images
-    </h2>
+  <% if post.id.present? %>
+    <%= govuk_one_third do %>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+        Images
+      </h2>
 
-    <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-2">
-      Shown at the bottom of a post
-    </p>
+      <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-2">
+        Shown at the bottom of a post
+      </p>
 
-    <%= turbo_frame_tag "images" do %>
-      <div class="app-upload">
-        <div class="app-upload__attachments">
-          <% post.ordered_images.each do |image| %>
-            <div class="app-upload__attachment">
-              <%= image_tag image,
-                class: 'govuk-!-margin-bottom-2',
-                style: 'max-width: 100%; border: 1px solid #000' %>
+      <%= turbo_frame_tag "images" do %>
+        <div class="app-upload">
+          <div class="app-upload__attachments">
+            <% post.ordered_images.each do |image| %>
+              <div class="app-upload__attachment">
+                <%= image_tag image,
+                  class: 'govuk-!-margin-bottom-2',
+                  style: 'max-width: 100%; border: 1px solid #000' %>
 
-              <div class="app-upload__attachment-buttons govuk-button-group">
-                <% unless @post.first_image?(image) %>
-                  <%= button_to up_project_post_image_path(@project, @post, image),
+                <div class="app-upload__attachment-buttons govuk-button-group">
+                  <% unless post.first_image?(image) %>
+                    <%= button_to up_project_post_image_path(@project, post, image),
+                      class: 'govuk-button govuk-button--secondary
+                              govuk-!-font-weight-bold' do %>
+                      ↑ <span class="govuk-visually-hidden">
+                        Move up image <%= image.id %></span>
+                    <% end %>
+                  <% end %>
+
+                  <% unless post.last_image?(image) %>
+                    <%= button_to down_project_post_image_path(@project, post, image),
+                      class: 'govuk-button govuk-button--secondary
+                              govuk-!-font-weight-bold' do %>
+                      ↓ <span class="govuk-visually-hidden">
+                        Move down image <%= image.id %></span>
+                    <% end %>
+                  <% end %>
+
+                  <%= button_to project_post_image_path(@project, post, image),
+                    method: :delete,
                     class: 'govuk-button govuk-button--secondary
                             govuk-!-font-weight-bold' do %>
-                    ↑ <span class="govuk-visually-hidden">
-                      Move up image <%= image.id %></span>
+                    × <span class="govuk-visually-hidden">
+                      Delete image <%= image.id %></span>
                   <% end %>
-                <% end %>
-
-                <% unless @post.last_image?(image) %>
-                  <%= button_to down_project_post_image_path(@project, @post, image),
-                    class: 'govuk-button govuk-button--secondary
-                            govuk-!-font-weight-bold' do %>
-                    ↓ <span class="govuk-visually-hidden">
-                      Move down image <%= image.id %></span>
-                  <% end %>
-                <% end %>
-
-                <%= button_to project_post_image_path(@project, @post, image),
-                  method: :delete,
-                  class: 'govuk-button govuk-button--secondary
-                          govuk-!-font-weight-bold' do %>
-                  × <span class="govuk-visually-hidden">
-                    Delete image <%= image.id %></span>
-                <% end %>
+                </div>
               </div>
-            </div>
+            <% end %>
+          </div>
+
+          <%= form_with(model: post,
+                        url: project_post_images_path(@project, post),
+                        method: :post) do |f| %>
+            <%= f.govuk_error_summary %>
+            <%= f.label :images, "Add more images",
+              class: 'govuk-label govuk-label--s govuk-!-margin-top-2
+                      govuk-!-margin-bottom-2' %>
+            <%= f.file_field :images,
+              multiple: true, accept: 'image/png,image/jpeg,image/gif' %>
+
+            <%= f.govuk_submit "Save images",
+              class: 'app-button govuk-!-margin-top-4' %>
           <% end %>
         </div>
-
-        <%= form_with(model: @post,
-                      url: project_post_images_path(@project, @post),
-                      method: :post) do |f| %>
-          <%= f.govuk_error_summary %>
-          <%= f.label :images, "Add more images",
-            class: 'govuk-label govuk-label--s govuk-!-margin-top-2
-                    govuk-!-margin-bottom-2' %>
-          <%= f.file_field :images,
-            multiple: true, accept: 'image/png,image/jpeg,image/gif' %>
-
-          <%= f.govuk_submit "Save images",
-            class: 'app-button govuk-!-margin-top-4' %>
-        <% end %>
-      </div>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,14 +14,16 @@
       </h1>
     </header>
 
-    <footer>
-      <p class="app-metadata">
-        <span class="govuk-visually-hidden">Posted on: </span>
-        <time datetime="<%= @post.updated_at.iso8601 %>">
-          <%= @post.published_at.strftime("%d %B %Y") %>
-        </time>
-      </p>
-    </footer>
+    <% if @post.published_at %>
+      <footer>
+        <p class="app-metadata">
+          <span class="govuk-visually-hidden">Posted on: </span>
+          <time datetime="<%= @post.published_at.iso8601 %>">
+            <%= @post.published_at.strftime("%d %B %Y") %>
+          </time>
+        </p>
+      </footer>
+    <% end %>
   </div>
 
   <%= govuk_two_thirds do %>


### PR DESCRIPTION
While building the last version of the image upload feature, post creation broke because adding images now requires an existing post. This temporarily disables adding images while writing the initial draft.