### PR TITLE
Configure inflector to not downcase some acronyms

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,9 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+#
+acronyms = %w[UK NHS DFE HMRC GDS]
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  acronyms.each { |acr| inflect.acronym acr }
+end


### PR DESCRIPTION
We don't want filenames with keywords like UK to end up as Uk after being humanized.

### Example for "UK post NHS.png"

![image](https://user-images.githubusercontent.com/1650875/203443629-1b8a8148-2db0-4f8b-bf93-dacf7b91d2cb.png)
