### PR TITLE
Add password protection feature

### DIFF
--- a/app/controllers/manage_access_controller.rb
+++ b/app/controllers/manage_access_controller.rb
@@ -4,7 +4,21 @@ class ManageAccessController < ApplicationController
   def edit
   end
 
+  def update
+    if @project.update(project_params)
+      redirect_to @project, notice: "Your changes have been saved"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
   def set_project
     @project = current_user.projects.find(params[:project_id])
+  end
+
+  def project_params
+    params.require(:project).permit(:private, :password)
   end
 end

--- a/app/controllers/manage_access_controller.rb
+++ b/app/controllers/manage_access_controller.rb
@@ -1,0 +1,10 @@
+class ManageAccessController < ApplicationController
+  before_action :set_project
+
+  def edit
+  end
+
+  def set_project
+    @project = current_user.projects.find(params[:project_id])
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -54,6 +54,15 @@ class ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:title, :subdomain, :description)
+    ps =
+      params.require(:project).permit(
+        :title,
+        :subdomain,
+        :description,
+        :private,
+        :password
+      )
+    ps[:password] = "" if ps.key?(:password) && ps.delete(:private) == "0"
+    ps
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -54,15 +54,6 @@ class ProjectsController < ApplicationController
   end
 
   def project_params
-    ps =
-      params.require(:project).permit(
-        :title,
-        :subdomain,
-        :description,
-        :private,
-        :password
-      )
-    ps[:password] = "" if ps.key?(:password) && ps.delete(:private) == "0"
-    ps
+    params.require(:project).permit(:title, :subdomain, :description)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -40,6 +40,6 @@ class Project < ApplicationRecord
             },
             uniqueness: true
   validates :description, presence: true, length: { maximum: 255 }
-  validates :password, length: { maximum: 50 }
+  validates :password, length: { maximum: 50 }, confirmation: true
   validates :password, presence: true, if: -> { private == "1" }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,6 +24,8 @@ class Project < ApplicationRecord
   belongs_to :user
   has_many :posts, dependent: :destroy
 
+  attr_accessor :private
+
   validates :title, presence: true, length: { maximum: 255 }
   validates :subdomain,
             presence: true,
@@ -39,4 +41,5 @@ class Project < ApplicationRecord
             uniqueness: true
   validates :description, presence: true, length: { maximum: 255 }
   validates :password, length: { maximum: 50 }
+  validates :password, presence: true, if: -> { private == "1" }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,7 @@
 #
 #  id          :bigint           not null, primary key
 #  description :string
+#  password    :string
 #  subdomain   :string
 #  title       :string
 #  created_at  :datetime         not null

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,4 +38,5 @@ class Project < ApplicationRecord
             },
             uniqueness: true
   validates :description, presence: true, length: { maximum: 255 }
+  validates :password, length: { maximum: 50 }
 end

--- a/app/views/app/password.html.erb
+++ b/app/views/app/password.html.erb
@@ -1,0 +1,20 @@
+<% title = "This design history is private" %>
+<%= content_for :page_title, (@project.errors.any? ? "Error: " : "") + title %>
+
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <%= form_with(model: @project, method: :post,
+                  url: app_confirm_password_path) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l"><%= title %></h1>
+
+      <p>You need to enter the password to continue.</p>
+
+      <%= f.govuk_text_field :password_confirmation,
+        label: { text: "Password", size: "s" } %>
+
+      <%= f.govuk_submit "Continue", class: 'app-button' %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/manage_access/edit.html.erb
+++ b/app/views/manage_access/edit.html.erb
@@ -1,0 +1,36 @@
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: {
+    "Your design histories" => projects_path,
+    @project.title => project_path(@project),
+    "Manage access" => nil
+  }) %>
+<% end %>
+
+<%= content_for :page_title, "Manage design history access" %>
+
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <%= form_with(model: @project) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Manage access</h1>
+
+      <%= f.govuk_check_boxes_fieldset :private,
+        multiple: false,
+        legend: { text: "You can set a design history as private. Users will be
+                  prompted for a password to access it.",
+                  size: "s", class: 'govuk-!-font-weight-regular' } do %>
+        <%= f.govuk_check_box :private, 1, 0,
+          checked: @project.password.present?,
+          multiple: false,
+          label: { text: "Make this design history private" },
+          link_errors: true do %>
+          <%= f.govuk_text_field :password,
+            label: { text: "Enter a password" } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit "Save changes", class: 'app-button' %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/manage_access/edit.html.erb
+++ b/app/views/manage_access/edit.html.erb
@@ -10,7 +10,8 @@
 
 <%= govuk_row do %>
   <%= govuk_two_thirds do %>
-    <%= form_with(model: @project) do |f| %>
+    <%= form_with(model: @project,
+                  url: project_manage_access_path(@project)) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">Manage access</h1>
@@ -21,7 +22,7 @@
                   prompted for a password to access it.",
                   size: "s", class: 'govuk-!-font-weight-regular' } do %>
         <%= f.govuk_check_box :private, 1, 0,
-          checked: @project.password.present?,
+          checked: @project.password.present? || @project.private == "1",
           multiple: false,
           label: { text: "Make this design history private" },
           link_errors: true do %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,6 +10,8 @@
   <%= govuk_link_to design_history_link(@project), design_history_link(@project) %>
   –
   <%= govuk_link_to "Change details", edit_project_path(@project) %>
+  –
+  <%= govuk_link_to "Manage access", project_manage_access_path(@project) %>
 </p>
 
 <%= govuk_button_link_to "New post", new_project_post_path(@project),

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,7 +1,8 @@
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: {
     "Your design histories" => projects_path,
-    @project.title => project_path(@project)
+    @project.title => project_path(@project),
+    "Change details" => nil
   }) %>
 <% end %>
 

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -33,6 +33,7 @@ en:
               too_long: Enter a description that is less than 255 characters
                 long
             password:
+              blank: Enter a password
               too_long: Enter a password that is less than 50 characters long
         post:
           attributes:

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -32,6 +32,8 @@ en:
               blank: Enter a description
               too_long: Enter a description that is less than 255 characters
                 long
+            password:
+              too_long: Enter a password that is less than 50 characters long
         post:
           attributes:
             title:

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -35,6 +35,8 @@ en:
             password:
               blank: Enter a password
               too_long: Enter a password that is less than 50 characters long
+            password_confirmation:
+              confirmation: The password is incorrect
         post:
           attributes:
             title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
     resources :projects do
       get "/manage-access", to: "manage_access#edit"
+      patch "/manage-access", to: "manage_access#update"
 
       resources :posts do
         resources :images,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     devise_for :users
 
     resources :projects do
+      get "/manage-access", to: "manage_access#edit"
+
       resources :posts do
         resources :images,
                   only: %i[create destroy],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,5 +36,9 @@ Rails.application.routes.draw do
   constraints domain: Rails.application.config.app_domain do
     get "/", to: "app#index", as: "app_posts"
     get "/:post_id", to: "app#show", as: "app_post"
+
+    post "/confirm-password",
+         to: "app#confirm_password",
+         as: "app_confirm_password"
   end
 end

--- a/db/migrate/20221126205618_add_password_to_projects.rb
+++ b/db/migrate/20221126205618_add_password_to_projects.rb
@@ -1,0 +1,5 @@
+class AddPasswordToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_22_235825) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_26_205618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_235825) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.string "subdomain"
+    t.string "password"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
     t.index ["user_id"], name: "index_projects_on_user_id"
   end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id                :bigint           not null, primary key
+#  body              :text
+#  ordered_image_ids :json
+#  published         :boolean
+#  published_at      :date
+#  slug              :string
+#  title             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  project_id        :bigint           not null
+#
+# Indexes
+#
+#  index_posts_on_project_id           (project_id)
+#  index_posts_on_project_id_and_slug  (project_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#
 FactoryBot.define do
   factory :post do
     title { Faker::Company.bs.capitalize }

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  password    :string
+#  subdomain   :string
+#  title       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_projects_on_subdomain  (subdomain) UNIQUE
+#  index_projects_on_user_id    (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :project do
     title { Faker::Company.name }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  sign_in_count          :integer          default(0), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }

--- a/spec/system/password_protection_spec.rb
+++ b/spec/system/password_protection_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe "Password protection" do
+  let(:user) { create(:user) }
+  let!(:project) { create(:project, user:, subdomain: "this") }
+
+  it "allows users to create private design histories" do
+    given_i_am_signed_in
+    when_i_visit_my_project_page
+    then_i_see_the_project_page
+
+    when_i_click_on_manage_access
+    then_i_see_the_manage_access_page
+
+    when_i_set_the_project_as_private
+    then_i_see_an_error
+
+    when_i_set_the_project_as_private_with_a_password
+    then_i_see_the_project_page
+
+    when_i_visit_my_design_history
+    then_i_am_asked_for_the_password
+
+    when_i_submit_an_invalid_password
+    then_i_see_an_error
+
+    when_i_submit_the_right_password
+    then_i_see_my_design_history
+
+    when_i_visit_my_project_page
+    and_i_click_on_manage_access
+    then_i_see_the_manage_access_page
+
+    when_i_change_the_password
+    then_i_see_the_project_page
+
+    when_i_visit_my_design_history
+    then_i_am_asked_for_the_password
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in user
+  end
+
+  def when_i_visit_my_project_page
+    visit project_path(project)
+  end
+
+  def then_i_see_the_project_page
+    expect(page).to have_content project.title
+  end
+
+  def when_i_click_on_manage_access
+    click_link "Manage access"
+  end
+  alias_method :and_i_click_on_manage_access, :when_i_click_on_manage_access
+
+  def then_i_see_the_manage_access_page
+    expect(page).to have_content "Manage access"
+  end
+
+  def when_i_set_the_project_as_private
+    check "project[private]", visible: false
+    click_button "Save changes"
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content "problem"
+  end
+
+  def when_i_set_the_project_as_private_with_a_password
+    check "project[private]", visible: false
+    fill_in "project[password]", with: "rosebud"
+    click_button "Save changes"
+  end
+
+  def when_i_visit_my_design_history
+    port = page.driver.browser.options.port
+    visit "http://this.app.local:#{port}"
+  end
+
+  def then_i_am_asked_for_the_password
+    expect(page).to have_content "This design history is private"
+  end
+
+  def when_i_submit_an_invalid_password
+    fill_in "project[password_confirmation]", with: "motherlode"
+    click_button "Continue"
+  end
+
+  def when_i_submit_the_right_password
+    fill_in "project[password_confirmation]", with: "rosebud"
+    click_button "Continue"
+  end
+
+  def then_i_see_my_design_history
+    expect(page).to have_content "#{project.title} design history"
+  end
+
+  def when_i_change_the_password
+    fill_in "project[password]", with: "motherlode"
+    click_button "Save changes"
+  end
+end


### PR DESCRIPTION
Note that the password field is set as a regular text field, both on the settings, and on the user confirmation page. This is intentional; I think because it's not an especially secure method of authentication, it makes sense to not hide it.

### Manage access link

![image](https://user-images.githubusercontent.com/1650875/204112698-ca2d8b34-b1d4-46e8-ae9c-dcdae8530268.png)

### Submitting without a password

![image](https://user-images.githubusercontent.com/1650875/204112723-d169f953-47dc-4828-9a91-3f154a4cc3f4.png)

### Submitting successfully

![image](https://user-images.githubusercontent.com/1650875/204112733-10a3548f-9e35-4af2-b4e5-7abf0ad8aff4.png)

### Password protected design history

![image](https://user-images.githubusercontent.com/1650875/204132916-74c0efa4-1e68-4ec7-982f-2491bf3ad917.png)