### PR TITLE
Incomplete teams support

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,5 +1,10 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_team, only: %i[show]
+
+  # GET /teams/1
+  def show
+  end
 
   # GET /teams/new
   def new
@@ -10,6 +15,7 @@ class TeamsController < ApplicationController
   def create
     @team = Team.new(team_params)
     if @team.save
+      current_user.update!(team: @team)
       redirect_to @team, notice: "Your team has been created"
     else
       render :new, status: :unprocessable_entity
@@ -17,6 +23,10 @@ class TeamsController < ApplicationController
   end
 
   private
+
+  def set_team
+    @team = current_user.team
+  end
 
   def team_params
     params.require(:team).permit(:name)

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,0 +1,18 @@
+class TeamsController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /teams/new
+  def new
+    @team = Team.new
+  end
+
+  # POST /teams
+  def create
+    # @project = current_user.projects.new(project_params)
+    # if @project.save
+    #   redirect_to @project, notice: "Your design history has been created"
+    # else
+    #   render :new, status: :unprocessable_entity
+    # end
+  end
+end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -8,11 +8,17 @@ class TeamsController < ApplicationController
 
   # POST /teams
   def create
-    # @project = current_user.projects.new(project_params)
-    # if @project.save
-    #   redirect_to @project, notice: "Your design history has been created"
-    # else
-    #   render :new, status: :unprocessable_entity
-    # end
+    @team = Team.new(team_params)
+    if @team.save
+      redirect_to @team, notice: "Your team has been created"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def team_params
+    params.require(:team).permit(:name)
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,9 +1,10 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: %i[show]
+  before_action :set_team, except: %i[new create]
 
   # GET /teams/1
   def show
+    @add_user_form = AddUserForm.new
   end
 
   # GET /teams/new
@@ -22,6 +23,17 @@ class TeamsController < ApplicationController
     end
   end
 
+  # POST /teams/1/add-user
+  def add_user
+    @add_user_form = AddUserForm.new(add_user_params)
+    @add_user_form.team = @team
+    if @add_user_form.save
+      redirect_to @team, notice: "User was successfully added"
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_team
@@ -30,5 +42,9 @@ class TeamsController < ApplicationController
 
   def team_params
     params.require(:team).permit(:name)
+  end
+
+  def add_user_params
+    params.require(:add_user_form).permit(:email)
   end
 end

--- a/app/forms/add_user_form.rb
+++ b/app/forms/add_user_form.rb
@@ -1,0 +1,25 @@
+class AddUserForm
+  include ActiveModel::Model
+
+  attr_accessor :email, :team
+  validates :email, presence: true
+  validates :team, presence: true
+
+  def save
+    return false if invalid?
+
+    user = User.find_by_email(email)
+
+    unless user
+      errors.add(:email, :not_found)
+      return false
+    end
+
+    if user.team.present?
+      errors.add(:email, :has_team)
+      return false
+    end
+
+    true
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,11 @@
+# == Schema Information
+#
+# Table name: teams
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Team < ApplicationRecord
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -9,4 +9,6 @@
 #
 class Team < ApplicationRecord
   has_many :users
+
+  validates :name, presence: true, length: { maximum: 50 }
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -8,4 +8,5 @@
 #  updated_at :datetime         not null
 #
 class Team < ApplicationRecord
+  has_many :users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,11 +15,17 @@
 #  sign_in_count          :integer          default(0), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  team_id                :bigint
 #
 # Indexes
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_team_id               (team_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (team_id => teams.id)
 #
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
@@ -32,4 +38,5 @@ class User < ApplicationRecord
          :validatable
 
   has_many :projects
+  belongs_to :team, optional: true
 end

--- a/app/views/manage_access/edit.html.erb
+++ b/app/views/manage_access/edit.html.erb
@@ -35,3 +35,12 @@
     <% end %>
   <% end %>
 <% end %>
+
+<h2>Teams</h2>
+
+<p>This design history belongs to you, and only you can edit it.</p>
+
+<p>
+  <%= govuk_link_to "Create a team", new_team_path %>
+  to allow others to collaborate with you.
+</p>

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -1,0 +1,22 @@
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <%= form_with(model: team) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">
+        <% if editing %>
+          Edit <%= team.name %>
+        <% else %>
+          New team
+        <% end %>
+      </h1>
+
+      <%= f.govuk_text_field :name,
+        label: {
+          class: 'govuk-label govuk-label--s'
+        } %>
+
+      <%= f.govuk_submit editing ? "Save changes" : "Create team",
+        class: 'app-button' %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -10,6 +10,15 @@
         <% end %>
       </h1>
 
+      <% unless editing %>
+        <p>You can:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>only be part of one team</li>
+          <li>invite others to your team</li>
+          <li>give a team ownership of your design histories</li>
+        </ul>
+      <% end %>
+
       <%= f.govuk_text_field :name,
         label: {
           class: 'govuk-label govuk-label--s'

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,0 +1,4 @@
+<% title = "New team" %>
+<%= content_for :page_title, title %>
+
+<%= render "form", team: @team, editing: false %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,4 +1,4 @@
-<% title = "New team" %>
+<% title = "#{@team.errors.any? ? "Error: " : "" }New team" %>
 <%= content_for :page_title, title %>
 
 <%= render "form", team: @team, editing: false %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,9 +1,29 @@
-<% title = "#{@team.name} settings" %>
+<% title = "#{@team.name} team settings" %>
 <%= content_for :page_title, title %>
-<h1 class="govuk-heading-xl"><%= title %></h1>
 
-<ul class="govuk-list govuk-list--bullets">
-  <% @team.users.each do |user| %>
-    <li><%= user.email %></li>
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <%= form_with(model: @add_user_form, url: add_user_team_path(@team)) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <p>Users:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <% @team.users.each do |user| %>
+          <li><%= user.email %></li>
+        <% end %>
+      </ul>
+
+      <h2>Add users to this team</h2>
+
+      <p>To add a user they must have an account and not be part of a team.</p>
+
+      <%= f.govuk_text_field :email,
+        label: { class: 'govuk-label govuk-label--s' } %>
+
+      <%= f.govuk_submit "Add user to team", class: 'app-button' %>
+    <% end %>
   <% end %>
-</ul>
+<% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,0 +1,9 @@
+<% title = "#{@team.name} settings" %>
+<%= content_for :page_title, title %>
+<h1 class="govuk-heading-xl"><%= title %></h1>
+
+<ul class="govuk-list govuk-list--bullets">
+  <% @team.users.each do |user| %>
+    <li><%= user.email %></li>
+  <% end %>
+</ul>

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -56,3 +56,10 @@ en:
             name:
               blank: Enter a name
               too_long: Enter a name that is less than 50 characters long
+  activemodel:
+    errors:
+      models:
+        add_user_form:
+          attributes:
+            email:
+              blank: Enter an email

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -51,3 +51,8 @@ en:
               blank: Enter a body
             published_at:
               blank: Enter a published at date
+        team:
+          attributes:
+            name:
+              blank: Enter a name
+              too_long: Enter a name that is less than 50 characters long

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
 
     devise_for :users
 
-    resources :teams
+    resources :teams do
+      post "/add-user", action: :add_user, on: :member
+    end
 
     resources :projects do
       get "/manage-access", to: "manage_access#edit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
 
     devise_for :users
 
+    resources :teams
+
     resources :projects do
       get "/manage-access", to: "manage_access#edit"
       patch "/manage-access", to: "manage_access#update"

--- a/db/migrate/20221127153056_create_teams.rb
+++ b/db/migrate/20221127153056_create_teams.rb
@@ -1,0 +1,9 @@
+class CreateTeams < ActiveRecord::Migration[7.0]
+  def change
+    create_table :teams do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221127153423_add_team_to_users.rb
+++ b/db/migrate/20221127153423_add_team_to_users.rb
@@ -1,0 +1,5 @@
+class AddTeamToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :users, :team, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_27_153056) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_27_153423) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -98,12 +98,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_27_153056) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "team_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["team_id"], name: "index_users_on_team_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "posts", "projects"
   add_foreign_key "projects", "users"
+  add_foreign_key "users", "teams"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_26_205618) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_27_153056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,6 +77,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_26_205618) do
     t.string "password"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
     t.index ["user_id"], name: "index_projects_on_user_id"
+  end
+
+  create_table "teams", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: teams
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :team do
+    name { FactoryBot::Company.bs.capitalize }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,11 +15,17 @@
 #  sign_in_count          :integer          default(0), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  team_id                :bigint
 #
 # Indexes
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_team_id               (team_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (team_id => teams.id)
 #
 FactoryBot.define do
   factory :user do

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Teams" do
   end
 
   def when_i_submit_an_invalid_email
-    fill_in "add_user[email]", with: Faker::Internet.email
+    fill_in "add_user_form[email]", with: Faker::Internet.email
     click_button "Add user"
   end
 
@@ -84,12 +84,12 @@ RSpec.describe "Teams" do
   end
 
   def when_i_submit_a_valid_email_from_a_user_with_a_team
-    fill_in "add_user[email]", with: user.email
+    fill_in "add_user_form[email]", with: user.email
     click_button "Add user"
   end
 
   def when_i_submit_a_valid_email
-    fill_in "add_user[email]", with: another_user.email
+    fill_in "add_user_form[email]", with: another_user.email
     click_button "Add user"
   end
 

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe "Teams" do
     when_i_submit_a_valid_email
     then_i_see_a_success_message
 
-    when_i_sign_in_as_another_user
-    and_i_visit_my_project_page
-    then_i_see_the_project_page
+    # when_i_sign_in_as_another_user
+    # and_i_visit_my_project_page
+    # then_i_see_the_project_page
   end
 
   private

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe "Teams" do
 
     when_i_click_on_create_a_team
     then_i_see_the_team_creation_page
+
+    when_i_submit_a_name
+    then_i_see_the_team_show_page
   end
 
   private
@@ -45,5 +48,14 @@ RSpec.describe "Teams" do
 
   def then_i_see_the_team_creation_page
     expect(page).to have_content "New team"
+  end
+
+  def when_i_submit_a_name
+    fill_in "team[name]", with: Faker::Company.bs.capitalize
+    click_button "Create team"
+  end
+
+  def then_i_see_the_team_show_page
+    expect(page).to have_content "settings"
   end
 end

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Teams" do
+  let(:user) { create(:user) }
+  let!(:project) { create(:project, user:, subdomain: "this") }
+
+  it "can manage access to projects" do
+    given_i_am_signed_in
+    when_i_visit_my_project_page
+    then_i_see_the_project_page
+
+    when_i_click_on_manage_access
+    then_i_see_the_manage_access_page
+
+    when_i_click_on_create_a_team
+    then_i_see_the_team_creation_page
+  end
+
+  private
+
+  def given_i_am_signed_in
+    sign_in user
+  end
+
+  def when_i_visit_my_project_page
+    visit project_path(project)
+  end
+
+  def then_i_see_the_project_page
+    expect(page).to have_content project.title
+  end
+
+  def when_i_click_on_manage_access
+    click_link "Manage access"
+  end
+  alias_method :and_i_click_on_manage_access, :when_i_click_on_manage_access
+
+  def then_i_see_the_manage_access_page
+    expect(page).to have_content "Manage access"
+  end
+
+  def when_i_click_on_create_a_team
+    click_link "Create a team"
+  end
+
+  def then_i_see_the_team_creation_page
+    expect(page).to have_content "New team"
+  end
+end

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Teams" do
   let(:user) { create(:user) }
+  let(:another_user) { create(:user) }
   let!(:project) { create(:project, user:, subdomain: "this") }
 
   it "can manage access to projects" do
@@ -13,10 +14,23 @@ RSpec.describe "Teams" do
     then_i_see_the_manage_access_page
 
     when_i_click_on_create_a_team
-    then_i_see_the_team_creation_page
+    then_i_see_the_team_create_page
 
     when_i_submit_a_name
     then_i_see_the_team_show_page
+
+    when_i_submit_an_invalid_email
+    then_i_see_an_error
+
+    when_i_submit_a_valid_email_from_a_user_with_a_team
+    then_i_see_an_error
+
+    when_i_submit_a_valid_email
+    then_i_see_a_success_message
+
+    when_i_sign_in_as_another_user
+    and_i_visit_my_project_page
+    then_i_see_the_project_page
   end
 
   private
@@ -28,6 +42,7 @@ RSpec.describe "Teams" do
   def when_i_visit_my_project_page
     visit project_path(project)
   end
+  alias_method :and_i_visit_my_project_page, :when_i_visit_my_project_page
 
   def then_i_see_the_project_page
     expect(page).to have_content project.title
@@ -46,7 +61,7 @@ RSpec.describe "Teams" do
     click_link "Create a team"
   end
 
-  def then_i_see_the_team_creation_page
+  def then_i_see_the_team_create_page
     expect(page).to have_content "New team"
   end
 
@@ -56,6 +71,33 @@ RSpec.describe "Teams" do
   end
 
   def then_i_see_the_team_show_page
-    expect(page).to have_content "settings"
+    expect(page).to have_content user.email
+  end
+
+  def when_i_submit_an_invalid_email
+    fill_in "add_user[email]", with: Faker::Internet.email
+    click_button "Add user"
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content "problem"
+  end
+
+  def when_i_submit_a_valid_email_from_a_user_with_a_team
+    fill_in "add_user[email]", with: user.email
+    click_button "Add user"
+  end
+
+  def when_i_submit_a_valid_email
+    fill_in "add_user[email]", with: another_user.email
+    click_button "Add user"
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_content "Success"
+  end
+
+  def when_i_sign_in_as_another_user
+    sign_in another_user
   end
 end


### PR DESCRIPTION
This branch was getting a bit too large, so I decided to merge in incomplete teams support.

This adds a new section in "Manage access" that allows you to create a team. Once you do so, your user is then associated with that team. Users can currently only be associated to one team at a time.

The teams show page has a form that allows you to invite other users to your team. This functionality is currently quite simplistic, and requires you to type in the user's exact email address, and they need to already have an account and to not be part of a team. So, it's enough for our own use, but requires a bit of refinement to be production-ready.

Follow-up PRs will contain things such as:

- Allow users to edit design histories belonging to their team
- Refine the UI, make it a bit nicer even if it's dev designed
- Fix some bugs, e.g. don't allow a user to create more than one team for now

### New team link in Manage access section

![image](https://user-images.githubusercontent.com/1650875/204358612-e2b7eff3-dcfa-4565-9872-0846b6b4eead.png)

### New team page

![image](https://user-images.githubusercontent.com/1650875/204358672-8714bad3-a612-4089-8b14-5eb323d709d6.png)

### Team show page

![image](https://user-images.githubusercontent.com/1650875/204358718-0c04e3c8-f438-4f8b-8d97-3fee6729c481.png)
