### PR TITLE
Add owner to projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.1.2"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", require: false
 gem "cssbundling-rails"
+gem "data_migrate"
 gem "devise"
 gem "friendly_id"
 gem "govuk-components"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,9 @@ GEM
     cuprite (0.14.3)
       capybara (~> 3.0)
       ferrum (~> 0.13.0)
+    data_migrate (8.2.0)
+      activerecord (>= 5.0)
+      railties (>= 5.0)
     debug (1.6.3)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
@@ -391,6 +394,7 @@ DEPENDENCIES
   bootsnap
   cssbundling-rails
   cuprite
+  data_migrate
   debug
   devise
   factory_bot_rails

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -24,7 +24,7 @@ class ProjectsController < ApplicationController
   # POST /projects
   def create
     @project = current_user.projects.new(project_params)
-
+    @project.user = current_user
     if @project.save
       redirect_to @project, notice: "Your design history has been created"
     else

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,6 +25,7 @@
 #
 class Project < ApplicationRecord
   belongs_to :user
+  belongs_to :owner, polymorphic: true
   has_many :posts, dependent: :destroy
 
   attr_accessor :private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,15 +4,18 @@
 #
 #  id          :bigint           not null, primary key
 #  description :string
+#  owner_type  :string
 #  password    :string
 #  subdomain   :string
 #  title       :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  owner_id    :bigint
 #  user_id     :bigint           not null
 #
 # Indexes
 #
+#  index_projects_on_owner      (owner_type,owner_id)
 #  index_projects_on_subdomain  (subdomain) UNIQUE
 #  index_projects_on_user_id    (user_id)
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,6 @@ class User < ApplicationRecord
          :trackable,
          :validatable
 
-  has_many :projects
+  has_many :projects, as: :owner
   belongs_to :team, optional: true
 end

--- a/db/data/20221128223253_use_owner_on_projects.rb
+++ b/db/data/20221128223253_use_owner_on_projects.rb
@@ -1,0 +1,12 @@
+class UseOwnerOnProjects < ActiveRecord::Migration[7.0]
+  def up
+    Project.all.each do |project|
+      project.owner = project.user
+      project.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20_221_128_223_253)

--- a/db/migrate/20221128224537_add_owner_to_projects.rb
+++ b/db/migrate/20221128224537_add_owner_to_projects.rb
@@ -1,0 +1,5 @@
+class AddOwnerToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :projects, :owner, polymorphic: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,6 +42,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_224537) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "friendly_id_slugs", force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_27_153423) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_224537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,6 +75,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_27_153423) do
     t.bigint "user_id", null: false
     t.string "subdomain"
     t.string "password"
+    t.string "owner_type"
+    t.bigint "owner_id"
+    t.index ["owner_type", "owner_id"], name: "index_projects_on_owner"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
     t.index ["user_id"], name: "index_projects_on_user_id"
   end

--- a/lib/tasks/fly.rake
+++ b/lib/tasks/fly.rake
@@ -12,7 +12,7 @@ namespace :fly do
   #  - full access to secrets, databases
   #  - failures here prevent deployment
   desc "Release"
-  task release: "db:migrate"
+  task release: "db:migrate:with_data"
 
   # SERVER step:
   #  - changes to the filesystem made here are deployed

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -4,15 +4,18 @@
 #
 #  id          :bigint           not null, primary key
 #  description :string
+#  owner_type  :string
 #  password    :string
 #  subdomain   :string
 #  title       :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  owner_id    :bigint
 #  user_id     :bigint           not null
 #
 # Indexes
 #
+#  index_projects_on_owner      (owner_type,owner_id)
 #  index_projects_on_subdomain  (subdomain) UNIQUE
 #  index_projects_on_user_id    (user_id)
 #

--- a/spec/system/design_histories_spec.rb
+++ b/spec/system/design_histories_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Design histories" do
   let(:user) { create(:user) }
-  let!(:project) { create(:project, user:, subdomain: "this") }
+  let!(:project) { create(:project, user:, owner: user, subdomain: "this") }
   let(:post_body) { "It's working" }
   let!(:first_post) { create(:post, project:, body: post_body) }
   let!(:second_post) { create(:post, project:, published: false) }

--- a/spec/system/password_protection_spec.rb
+++ b/spec/system/password_protection_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Password protection" do
   let(:user) { create(:user) }
-  let!(:project) { create(:project, user:, subdomain: "this") }
+  let!(:project) { create(:project, user:, owner: user, subdomain: "this") }
 
   it "allows users to create private design histories" do
     given_i_am_signed_in

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Posts" do
   let(:user) { create(:user) }
-  let!(:project) { create(:project, user:) }
+  let!(:project) { create(:project, user:, owner: user) }
 
   it "can be created" do
     given_i_am_signed_in

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Teams" do
   let(:user) { create(:user) }
   let(:another_user) { create(:user) }
-  let!(:project) { create(:project, user:, subdomain: "this") }
+  let!(:project) { create(:project, user:, owner: user, subdomain: "this") }
 
   it "can manage access to projects" do
     given_i_am_signed_in


### PR DESCRIPTION
Sets up a new `owner` reference from projects to users, which allows us to make projects belong to either a user, or a team. Also migrates existing user references, and updates tests accordingly.

Removing the user reference will be done as a follow-up; this needs to deploy fully as a prerequisite.