### PR TITLE
Replace user with owner on projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -24,7 +24,6 @@ class ProjectsController < ApplicationController
   # POST /projects
   def create
     @project = current_user.projects.new(project_params)
-    @project.user = current_user
     if @project.save
       redirect_to @project, notice: "Your design history has been created"
     else

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,7 +24,6 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Project < ApplicationRecord
-  belongs_to :user
   belongs_to :owner, polymorphic: true
   has_many :posts, dependent: :destroy
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,24 +4,18 @@
 #
 #  id          :bigint           not null, primary key
 #  description :string
-#  owner_type  :string
+#  owner_type  :string           not null
 #  password    :string
 #  subdomain   :string
 #  title       :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  owner_id    :bigint
-#  user_id     :bigint           not null
+#  owner_id    :bigint           not null
 #
 # Indexes
 #
 #  index_projects_on_owner      (owner_type,owner_id)
 #  index_projects_on_subdomain  (subdomain) UNIQUE
-#  index_projects_on_user_id    (user_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
 #
 class Project < ApplicationRecord
   belongs_to :owner, polymorphic: true

--- a/db/migrate/20221128230116_remove_user_from_projects.rb
+++ b/db/migrate/20221128230116_remove_user_from_projects.rb
@@ -1,0 +1,5 @@
+class RemoveUserFromProjects < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :projects, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20221128230901_set_owner_not_null_on_projects.rb
+++ b/db/migrate/20221128230901_set_owner_not_null_on_projects.rb
@@ -1,0 +1,6 @@
+class SetOwnerNotNullOnProjects < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :projects, :owner_id, false
+    change_column_null :projects, :owner_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_28_230116) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_230901) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,8 +77,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_230116) do
     t.datetime "updated_at", null: false
     t.string "subdomain"
     t.string "password"
-    t.string "owner_type"
-    t.bigint "owner_id"
+    t.string "owner_type", null: false
+    t.bigint "owner_id", null: false
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_28_224537) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_230116) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,14 +75,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_224537) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
     t.string "subdomain"
     t.string "password"
     t.string "owner_type"
     t.bigint "owner_id"
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
-    t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
   create_table "teams", force: :cascade do |t|
@@ -113,6 +111,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_224537) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "posts", "projects"
-  add_foreign_key "projects", "users"
   add_foreign_key "users", "teams"
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -4,24 +4,18 @@
 #
 #  id          :bigint           not null, primary key
 #  description :string
-#  owner_type  :string
+#  owner_type  :string           not null
 #  password    :string
 #  subdomain   :string
 #  title       :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  owner_id    :bigint
-#  user_id     :bigint           not null
+#  owner_id    :bigint           not null
 #
 # Indexes
 #
 #  index_projects_on_owner      (owner_type,owner_id)
 #  index_projects_on_subdomain  (subdomain) UNIQUE
-#  index_projects_on_user_id    (user_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :project do

--- a/spec/system/design_histories_spec.rb
+++ b/spec/system/design_histories_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Design histories" do
-  let(:user) { create(:user) }
-  let!(:project) { create(:project, user:, owner: user, subdomain: "this") }
+  let(:owner) { create(:user) }
+  let!(:project) { create(:project, owner:, subdomain: "this") }
   let(:post_body) { "It's working" }
   let!(:first_post) { create(:post, project:, body: post_body) }
   let!(:second_post) { create(:post, project:, published: false) }

--- a/spec/system/password_protection_spec.rb
+++ b/spec/system/password_protection_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Password protection" do
-  let(:user) { create(:user) }
-  let!(:project) { create(:project, user:, owner: user, subdomain: "this") }
+  let(:owner) { create(:user) }
+  let!(:project) { create(:project, owner:, subdomain: "this") }
 
   it "allows users to create private design histories" do
     given_i_am_signed_in
@@ -41,7 +41,7 @@ RSpec.describe "Password protection" do
   private
 
   def given_i_am_signed_in
-    sign_in user
+    sign_in owner
   end
 
   def when_i_visit_my_project_page

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Posts" do
-  let(:user) { create(:user) }
-  let!(:project) { create(:project, user:, owner: user) }
+  let(:owner) { create(:user) }
+  let!(:project) { create(:project, owner:) }
 
   it "can be created" do
     given_i_am_signed_in
@@ -19,7 +19,7 @@ RSpec.describe "Posts" do
   private
 
   def given_i_am_signed_in
-    sign_in user
+    sign_in owner
   end
 
   def when_i_visit_my_project

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "Teams" do
-  let(:user) { create(:user) }
+  let(:owner) { create(:user) }
   let(:another_user) { create(:user) }
-  let!(:project) { create(:project, user:, owner: user, subdomain: "this") }
+  let!(:project) { create(:project, owner:, subdomain: "this") }
 
   it "can manage access to projects" do
     given_i_am_signed_in
@@ -36,7 +36,7 @@ RSpec.describe "Teams" do
   private
 
   def given_i_am_signed_in
-    sign_in user
+    sign_in owner
   end
 
   def when_i_visit_my_project_page
@@ -71,7 +71,7 @@ RSpec.describe "Teams" do
   end
 
   def then_i_see_the_team_show_page
-    expect(page).to have_content user.email
+    expect(page).to have_content owner.email
   end
 
   def when_i_submit_an_invalid_email
@@ -84,7 +84,7 @@ RSpec.describe "Teams" do
   end
 
   def when_i_submit_a_valid_email_from_a_user_with_a_team
-    fill_in "add_user_form[email]", with: user.email
+    fill_in "add_user_form[email]", with: owner.email
     click_button "Add user"
   end
 


### PR DESCRIPTION
Completes the migration to the new owner field, and makes the owner columns not nullable to prevent orphaned projects from occurring.