### PR TITLE
Update manage access design

### DIFF
--- a/app/controllers/manage_access_controller.rb
+++ b/app/controllers/manage_access_controller.rb
@@ -19,6 +19,6 @@ class ManageAccessController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:private, :password)
+    params.require(:project).permit(:visibility, :password)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,7 +21,7 @@ class Project < ApplicationRecord
   belongs_to :owner, polymorphic: true
   has_many :posts, dependent: :destroy
 
-  attr_accessor :private
+  attr_accessor :visibility
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :subdomain,
@@ -38,5 +38,5 @@ class Project < ApplicationRecord
             uniqueness: true
   validates :description, presence: true, length: { maximum: 255 }
   validates :password, length: { maximum: 50 }, confirmation: true
-  validates :password, presence: true, if: -> { private == "1" }
+  validates :password, presence: true, if: -> { visibility == "private" }
 end

--- a/app/views/manage_access/edit.html.erb
+++ b/app/views/manage_access/edit.html.erb
@@ -16,22 +16,21 @@
 
       <h1 class="govuk-heading-xl">Manage access</h1>
 
-      <%= f.govuk_check_boxes_fieldset :private,
-        multiple: false,
-        legend: { text: "You can set a design history as private. Users will be
-                  prompted for a password to access it.",
-                  size: "s", class: 'govuk-!-font-weight-regular' } do %>
-        <%= f.govuk_check_box :private, 1, 0,
-          checked: @project.password.present? || @project.private == "1",
-          multiple: false,
-          label: { text: "Make this design history private" },
-          link_errors: true do %>
+      <%= f.govuk_radio_buttons_fieldset(:visibility,
+          legend: { size: 'm', text: 'Who can see this design history' }) do %>
+        <%= f.govuk_radio_button :visibility, 'public',
+          checked: @project.password.blank? || @project.visibility == 'public',
+          label: { text: 'Everyone (public)' },
+          link_errors: true %>
+        <%= f.govuk_radio_button :visibility, 'private',
+          checked: @project.password.present? || @project.visibility == 'private',
+          label: { text: 'Only people with a password (private)' } do %>
           <%= f.govuk_text_field :password,
-            label: { text: "Enter a password" } %>
+            label: { text: 'Enter a password' } %>
         <% end %>
       <% end %>
 
-      <%= f.govuk_submit "Save changes", class: 'app-button' %>
+      <%= f.govuk_submit "Update visibility", class: 'app-button' %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/system/password_protection_spec.rb
+++ b/spec/system/password_protection_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe "Password protection" do
   end
 
   def when_i_set_the_project_as_private
-    check "project[private]", visible: false
-    click_button "Save changes"
+    choose "private", visible: false
+    click_button "Update visibility"
   end
 
   def then_i_see_an_error
@@ -71,9 +71,9 @@ RSpec.describe "Password protection" do
   end
 
   def when_i_set_the_project_as_private_with_a_password
-    check "project[private]", visible: false
+    choose "private", visible: false
     fill_in "project[password]", with: "rosebud"
-    click_button "Save changes"
+    click_button "Update visibility"
   end
 
   def when_i_visit_my_design_history
@@ -101,6 +101,6 @@ RSpec.describe "Password protection" do
 
   def when_i_change_the_password
     fill_in "project[password]", with: "motherlode"
-    click_button "Save changes"
+    click_button "Update visibility"
   end
 end


### PR DESCRIPTION
Offer a user two radio buttons instead of one checkbox, and update the content.

![image](https://user-images.githubusercontent.com/1650875/204669978-8ddd234f-d2c1-41a3-9a88-752be9401252.png)
