### PR TITLE
Add button to add a project to a team

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,7 +14,7 @@ class ProjectsController < ApplicationController
 
   # GET /projects/new
   def new
-    @project = current_user.projects.new
+    @project = current_user.own_projects.new
   end
 
   # GET /projects/1/edit
@@ -23,7 +23,7 @@ class ProjectsController < ApplicationController
 
   # POST /projects
   def create
-    @project = current_user.projects.new(project_params)
+    @project = current_user.own_projects.new(project_params)
     if @project.save
       redirect_to @project, notice: "Your design history has been created"
     else

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -34,6 +34,14 @@ class TeamsController < ApplicationController
     end
   end
 
+  # POST /teams/1/add-project/1
+  def add_project
+    project = Project.find(add_project_params)
+    project.update!(owner: @team)
+    redirect_to project_manage_access_path(project),
+                notice: "Design history was added to your team"
+  end
+
   private
 
   def set_team
@@ -46,5 +54,9 @@ class TeamsController < ApplicationController
 
   def add_user_params
     params.require(:add_user_form).permit(:email)
+  end
+
+  def add_project_params
+    params.require(:project_id)
   end
 end

--- a/app/forms/add_user_form.rb
+++ b/app/forms/add_user_form.rb
@@ -20,6 +20,8 @@ class AddUserForm
       return false
     end
 
+    user.update!(team:)
+
     true
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -9,6 +9,7 @@
 #
 class Team < ApplicationRecord
   has_many :users
+  has_many :projects, as: :owner
 
   validates :name, presence: true, length: { maximum: 50 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,17 @@ class User < ApplicationRecord
          :trackable,
          :validatable
 
-  has_many :projects, as: :owner
   belongs_to :team, optional: true
+
+  def projects
+    own_projects.or team_projects
+  end
+
+  def own_projects
+    Project.where owner: self
+  end
+
+  def team_projects
+    Project.where owner: team
+  end
 end

--- a/app/views/manage_access/edit.html.erb
+++ b/app/views/manage_access/edit.html.erb
@@ -37,9 +37,23 @@
 
 <h2>Teams</h2>
 
-<p>This design history belongs to you, and only you can edit it.</p>
+<% if @project.owner == current_user.team %>
+  <p>This design history belongs to your team. Anyone can edit.</p>
+<% else %>
+  <p>This design history belongs to you. Only you can edit it.</p>
 
-<p>
-  <%= govuk_link_to "Create a team", new_team_path %>
-  to allow others to collaborate with you.
-</p>
+  <% if current_user.team.present? %>
+    <p>
+      You can add this design history to your team.
+    </p>
+
+    <%= govuk_button_to "Add to team",
+      add_project_team_path(current_user.team, project_id: @project.id),
+      class: 'app-button' %>
+  <% else %>
+    <p>
+      <%= govuk_link_to "Create a team", new_team_path %>
+      to allow others to collaborate with you.
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -8,13 +8,23 @@
 
       <h1 class="govuk-heading-xl"><%= title %></h1>
 
-      <p>Users:</p>
+      <h2>Users</h2>
 
       <ul class="govuk-list govuk-list--bullet">
         <% @team.users.each do |user| %>
           <li><%= user.email %></li>
         <% end %>
       </ul>
+
+      <% if @team.projects.any? %>
+        <h2>Projects</h2>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <% @team.projects.each do |project| %>
+            <li><%= govuk_link_to project.title, project %></li>
+          <% end %>
+        </ul>
+      <% end %>
 
       <h2>Add users to this team</h2>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
     resources :teams do
       post "/add-user", action: :add_user, on: :member
+      post "/add-project", action: :add_project, on: :member
     end
 
     resources :projects do

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Teams" do
     then_i_see_the_manage_access_page
 
     when_i_click_on_create_a_team
-    then_i_see_the_team_create_page
+    then_i_see_the_create_a_team_page
 
     when_i_submit_a_name
     then_i_see_the_team_show_page
@@ -22,22 +22,29 @@ RSpec.describe "Teams" do
     then_i_see_an_error
 
     when_i_submit_a_valid_email
+    then_i_see_my_new_user
+
+    when_i_visit_my_project_page
+    and_i_click_on_manage_access
+    then_i_see_the_add_to_team_button
+
+    when_i_click_the_add_to_team_button
     then_i_see_a_success_message
 
-    # when_i_sign_in_as_another_user
-    # and_i_visit_my_project_page
-    # then_i_see_the_project_page
+    when_i_sign_in_as_another_user
+    and_i_visit_my_project_page
+    then_i_see_the_project_page
   end
 
   private
 
   def given_i_am_signed_in
     @owner = create(:user)
+    @project = create(:project, owner: @owner, subdomain: "this")
     sign_in @owner
   end
 
   def when_i_visit_my_project_page
-    @project = create(:project, owner: @owner, subdomain: "this")
     visit project_path(@project)
   end
   alias_method :and_i_visit_my_project_page, :when_i_visit_my_project_page
@@ -59,7 +66,7 @@ RSpec.describe "Teams" do
     click_link "Create a team"
   end
 
-  def then_i_see_the_team_create_page
+  def then_i_see_the_create_a_team_page
     expect(page).to have_content "New team"
   end
 
@@ -92,11 +99,23 @@ RSpec.describe "Teams" do
     click_button "Add user"
   end
 
-  def then_i_see_a_success_message
-    expect(page).to have_content "Success"
+  def then_i_see_my_new_user
+    expect(page).to have_content @another_user.email
   end
 
   def when_i_sign_in_as_another_user
     sign_in @another_user
+  end
+
+  def then_i_see_the_add_to_team_button
+    expect(page).to have_content "Add to team"
+  end
+
+  def when_i_click_the_add_to_team_button
+    click_button "Add to team"
+  end
+
+  def then_i_see_a_success_message
+    expect(page).to have_content "Success"
   end
 end


### PR DESCRIPTION
This completes the journey that allows users to create a team, invite other users to their team, and then add a project to that team.

I'll do a separate PR to take another pass at the design and make the pages a bit nicer.

Commits can be reviewed one by one.

### Adding a user to a team successfully

![image](https://user-images.githubusercontent.com/1650875/205133051-070a8e38-dc22-4f89-8852-c1897b376dcf.png)

### Manage access on a project, with a team - button to add to team present

![image](https://user-images.githubusercontent.com/1650875/205133169-8b09e5f9-1eee-4698-b431-c1454d8fed1e.png)

### Project added to team

![image](https://user-images.githubusercontent.com/1650875/205133235-e883b26a-7bde-4dd7-a002-3d4a5248b043.png)

### Second user can now view the project

![image](https://user-images.githubusercontent.com/1650875/205133332-03a2ee69-7cd4-4ac8-b2a4-a645058f4071.png)


### Projects page (after adding a project)

![image](https://user-images.githubusercontent.com/1650875/205132780-dde6d5cf-230a-43ce-af89-73bf271d3794.png)
