### PR TITLE
Add stylesheets for dh/gov/nhs themes

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,5 +1,7 @@
 .app-header {
   &--design-history {
+    background: $app-header-background-colour;
+
     .govuk-header__logo {
       width: auto;
       margin-top: govuk-spacing(5);
@@ -7,14 +9,14 @@
     }
 
     .govuk-header__container {
-      border-bottom-color: $app-header-bar-colour;
+      border-bottom: $app-header-border-width solid $app-header-bar-colour;
     }
   }
 
   &--admin {
     padding-top: 40px;
-    padding-bottom: 10px;
-    border-bottom: 10px solid $app-header-bar-colour;
+    padding-bottom: -$app-header-border-width;
+    border-bottom: $app-header-border-width solid $app-header-bar-colour;
 
     .govuk-header__container {
       border-bottom-width: 0;

--- a/app/assets/stylesheets/_masthead.scss
+++ b/app/assets/stylesheets/_masthead.scss
@@ -1,6 +1,6 @@
 $x-govuk-masthead-background-colour: $app-masthead-colour;
 $x-govuk-masthead-border-colour: govuk-tint($govuk-brand-colour, 25%);
-$x-govuk-masthead-colour: govuk-colour("black");
+$x-govuk-masthead-colour: $app-masthead-text-colour;
 
 .x-govuk-masthead {
   @include govuk-responsive-padding(7, "bottom");

--- a/app/assets/stylesheets/_upload.scss
+++ b/app/assets/stylesheets/_upload.scss
@@ -1,8 +1,8 @@
 .app-upload {
   input[type="file"] {
-    background-color: govuk-tint($app-brand-colour, 80%);
+    background-color: govuk-tint($app-upload-colour, 80%);
     box-sizing: border-box;
-    border: 2px dashed $app-button-colour;
+    border: 2px dashed $app-upload-colour;
     padding: govuk-spacing(4);
     width: 100%;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-font-family: "Inter", "HelveticaNeue", "Helvetica Neue", "Arial",
 
 $app-button-colour: #288080;
 $app-brand-colour: #c1dede;
+$app-upload-colour: $app-brand-colour;
 $app-header-bar-colour: $app-button-colour;
 $app-masthead-colour: $app-brand-colour;
 $app-tint-colour: govuk-tint($app-masthead-colour, 50%);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,19 +1,11 @@
-$govuk-global-styles: true;
-$govuk-new-link-styles: true;
-$govuk-assets-path: "/";
-
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
 $govuk-font-family: "Inter", "HelveticaNeue", "Helvetica Neue", "Arial",
   "Helvetica", sans-serif;
 
-$app-button-colour: #288080;
-$app-brand-colour: #c1dede;
-$app-upload-colour: $app-brand-colour;
-$app-header-bar-colour: $app-button-colour;
-$app-masthead-colour: $app-brand-colour;
-$app-tint-colour: govuk-tint($app-masthead-colour, 50%);
+$govuk-global-styles: true;
+$govuk-new-link-styles: true;
+$govuk-assets-path: "/";
 
-@import "govuk-frontend/govuk/base";
 $govuk-button-background-colour: $app-button-colour;
 @import "govuk-frontend/govuk/all";
 
@@ -47,7 +39,7 @@ $govuk-button-background-colour: $app-button-colour;
 }
 
 .app-holding-screenshot {
-  border-bottom: 20px solid $app-button-colour;
+  border-bottom: 20px solid $app-header-bar-colour;
   margin-top: govuk-spacing(4);
   max-width: 100%;
   margin-bottom: -38px;

--- a/app/assets/stylesheets/dh.scss
+++ b/app/assets/stylesheets/dh.scss
@@ -1,0 +1,17 @@
+@import "govuk-frontend/govuk/base";
+
+$app-brand-colour: #c1dede;
+$app-button-colour: #288080;
+
+$app-header-background-colour: govuk-colour("black");
+$app-header-bar-colour: $app-button-colour;
+$app-header-border-width: 10px;
+
+$app-masthead-text-colour: govuk-colour("black");
+$app-masthead-colour: $app-brand-colour;
+
+$app-tint-colour: govuk-tint($app-masthead-colour, 50%);
+
+$app-upload-colour: $app-brand-colour;
+
+@import "application";

--- a/app/assets/stylesheets/gov.scss
+++ b/app/assets/stylesheets/gov.scss
@@ -1,0 +1,17 @@
+@import "govuk-frontend/govuk/base";
+
+$app-brand-colour: govuk-colour("blue");
+$app-button-colour: govuk-colour("green");
+
+$app-header-background-colour: govuk-colour("black");
+$app-header-bar-colour: $app-brand-colour;
+$app-header-border-width: 10px;
+
+$app-masthead-colour: $app-brand-colour;
+$app-masthead-text-colour: govuk-colour("white");
+
+$app-tint-colour: govuk-colour("light-grey");
+
+$app-upload-colour: $app-brand-colour;
+
+@import "application";

--- a/app/assets/stylesheets/nhs.scss
+++ b/app/assets/stylesheets/nhs.scss
@@ -1,0 +1,17 @@
+@import "govuk-frontend/govuk/base";
+
+$app-brand-colour: #005eb8;
+$app-button-colour: $app-brand-colour;
+
+$app-header-background-colour: $app-brand-colour;
+$app-header-bar-colour: govuk-colour("white");
+$app-header-border-width: 2px;
+
+$app-masthead-colour: $app-brand-colour;
+$app-masthead-text-colour: govuk-colour("white");
+
+$app-tint-colour: govuk-colour("light-grey");
+
+$app-upload-colour: $app-brand-colour;
+
+@import "application";

--- a/app/assets/stylesheets/themes.txt
+++ b/app/assets/stylesheets/themes.txt
@@ -1,0 +1,3 @@
+./app/assets/stylesheets/dh.scss:./app/assets/builds/dh.css
+./app/assets/stylesheets/gov.scss:./app/assets/builds/gov.css
+./app/assets/stylesheets/nhs.scss:./app/assets/builds/nhs.css

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -18,7 +18,7 @@
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "dh", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= hotwire_livereload_tags if Rails.env.development? %>
   </head>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "sass": "^1.56.1"
   },
   "scripts": {
-    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet-deps",
+    "build:css": "sass $(cat ./app/assets/stylesheets/themes.txt) --no-source-map --load-path=node_modules --quiet-deps",
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets"
   },
   "devDependencies": {


### PR DESCRIPTION
Ensure they are compiled by the sass command. Adds a `themes.txt` which is meant to contain the Sass input/output arguments.

Also extracts some more variables from various components that need to look different depending on the theme.

| Theme | Password | Index | Show |
| - | - | - | - |
| Design history | ![image](https://user-images.githubusercontent.com/1650875/205460247-a945db7a-496a-444f-8a93-c1d261ae0218.png) | ![image](https://user-images.githubusercontent.com/1650875/205460284-ff512170-948c-4591-9858-d641639e7bce.png) | ![image](https://user-images.githubusercontent.com/1650875/205460290-b7ae302e-0d0c-4d04-a3f5-4da90f5514f2.png) |
| Government | ![image](https://user-images.githubusercontent.com/1650875/205460317-e5a4101c-82d1-43d1-9360-97d195b5e46f.png) | ![image](https://user-images.githubusercontent.com/1650875/205460328-f46e497c-8438-47b2-a5be-cba06e021e5b.png) | ![image](https://user-images.githubusercontent.com/1650875/205460333-985dd9a5-ce8a-436e-abd9-ea6e96a6d350.png) |
| Healthcare | ![image](https://user-images.githubusercontent.com/1650875/205460358-34a2fb33-4ca3-4f6a-9752-92f3d18a1068.png) | ![image](https://user-images.githubusercontent.com/1650875/205460371-59a5c2be-8767-4603-8392-1a0bd3f7dd0b.png) | ![image](https://user-images.githubusercontent.com/1650875/205460404-1b4238f3-c8aa-4654-9f62-9b41301f339d.png) |