### PR TITLE
Add ARM64 Darwin 22 architecture

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,6 +396,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Allows setup on an M2 MacBook.