### PR TITLE
Update footer design

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -41,23 +41,15 @@
       <%= render GovukComponent::FooterComponent.new do |footer|
         footer.meta do %>
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          <h2 class="govuk-visually-hidden">Support links</h2>
-
-          <ul class="govuk-footer__inline-list">
-            <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link"
-                 href="https://this.designhistory.app">
-                This design history</a>
-            </li>
-            <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link"
-                 href="https://github.com/design-history/design-history/">
-                Source code</a>
-            </li>
-          </ul>
-        </div>
-        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          <p>© Design History 2022</p>
+          <p>
+            © 2022–<%= Time.now.year %>. Built with
+            <a class="govuk-footer__link"
+               href="https://this.designhistory.app">
+              Design history</a>.
+            <a class="govuk-footer__link"
+               href="https://github.com/design-history/design-history/">
+              Source code on GitHub</a>.
+          </p>
         </div>
       <% end; end %>
     </div>


### PR DESCRIPTION
Consolidate the two links next to the copyright notice.

I've decided to keep the source code link in the page, as it's something I personally tend to look for when I'm using other websites.

Fixes #151.

### Before

![image](https://user-images.githubusercontent.com/1650875/214071406-fc7eeabf-65a9-40a0-94ba-238b9637c6d4.png)

### After

![image](https://user-images.githubusercontent.com/1650875/214071448-c9aabbed-4be8-4eca-b523-828e1c7c4ca0.png)
