### PR TITLE
Correct font size for footer text

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -41,7 +41,7 @@
       <%= render GovukComponent::FooterComponent.new do |footer|
         footer.meta do %>
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          <p>
+          <div class="govuk-footer__meta-custom">
             © 2022–<%= Time.now.year %>. Built with
             <a class="govuk-footer__link"
                href="https://this.designhistory.app">
@@ -49,7 +49,7 @@
             <a class="govuk-footer__link"
                href="https://github.com/design-history/design-history/">
               Source code on GitHub</a>.
-          </p>
+          </div>
         </div>
       <% end; end %>
     </div>


### PR DESCRIPTION
Using a paragraph element renders the footer font larger (19px) than intended (16px). Following convention used on other sites that use `govuk-frontend`, use a `div` and give it a class of `govuk-footer__meta-custom` (which while not necessary, adds a margin below which may be useful if further content is added later, and also follows the conventions used elsewhere).

(Not sure if `govuk-components` has a slot for this, I think it’s pretty much the Wild West when it comes to the footer component!)