### PR TITLE
Authenticate users for manage access controller

### DIFF
--- a/app/controllers/manage_access_controller.rb
+++ b/app/controllers/manage_access_controller.rb
@@ -1,4 +1,5 @@
 class ManageAccessController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_project
 
   def edit


### PR DESCRIPTION
Without this, a user that attempts to access the edit page and isn't signed in will encounter a 500, as per this Sentry error: https://sentry.io/organizations/design-history/issues/3887506917/?project=4504255433539584