### PR TITLE
Add blockquote styling

### DIFF
--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -13,3 +13,13 @@ h3:not([class]) {
 h4:not([class]) {
   @extend .govuk-heading-s;
 }
+
+blockquote {
+  border-left: govuk-spacing(2) solid $govuk-border-colour;
+  padding: 1em 0 1em 1em;
+  margin: 2em 0;
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
This is implemented as a global rule because it's a pretty specific element and it's unlikely to clash with other 3rd party rules.

Styles stolen from GOV.UK.

### After

![image](https://user-images.githubusercontent.com/1650875/214526389-88ecc8d0-25ed-494f-93e3-038bf25dfa1c.png)
