### PR TITLE
Increase cookie length to 1 year

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 Rails.application.config.session_store :cookie_store,
                                        secure: Rails.env.production?,
-                                       expire_after: 2.hours
+                                       expire_after: 1.year


### PR DESCRIPTION
After a user has given a password for a private design history, we don't really want to be asking again.