### PR TITLE
Fix related links bugs

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,7 +7,7 @@
 #  ordered_image_ids :json
 #  published         :boolean
 #  published_at      :date
-#  related_links     :text
+#  related_links     :text             default("")
 #  slug              :string
 #  title             :string
 #  created_at        :datetime         not null

--- a/app/views/app/show.html.erb
+++ b/app/views/app/show.html.erb
@@ -32,11 +32,12 @@
   <% end %>
 
   <%= govuk_one_third do %>
-    <div class="app-related-links">
-      <h2 class="app-related-links__main-heading">
-        Related links
+    <nav class="app-related-links" role="navigation"
+         aria-labelledby="related-content">
+      <h2 class="app-related-links__main-heading" id="related-content">
+        Related content
       </h2>
       <%= GovukMarkdown.render(@post.related_links).html_safe %>
-    </div>
+    </nav>
   <% end %>
 <% end %>

--- a/app/views/app/show.html.erb
+++ b/app/views/app/show.html.erb
@@ -32,12 +32,14 @@
   <% end %>
 
   <%= govuk_one_third do %>
-    <nav class="app-related-links" role="navigation"
-         aria-labelledby="related-content">
-      <h2 class="app-related-links__main-heading" id="related-content">
-        Related content
-      </h2>
-      <%= GovukMarkdown.render(@post.related_links).html_safe %>
-    </nav>
+    <% if @post.related_links.present? %>
+      <nav class="app-related-links" role="navigation"
+           aria-labelledby="related-content">
+        <h2 class="app-related-links__main-heading" id="related-content">
+          Related content
+        </h2>
+        <%= GovukMarkdown.render(@post.related_links).html_safe %>
+      </nav>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -20,7 +20,7 @@
         hint: { text: 'Use markdown for links, headings and images',
                 class: 'govuk-hint govuk-!-font-size-16' } %>
       <%= f.govuk_text_area :related_links, rows: 4,
-        label: { text: 'Related links', size: 's' },
+        label: { text: 'Related content', size: 's' },
         hint: { text: 'Use markdown for links',
                 class: 'govuk-hint govuk-!-font-size-16' } %>
       <%= f.govuk_check_boxes_fieldset :published, multiple: false,

--- a/db/migrate/20230125113130_set_default_on_post_related_links.rb
+++ b/db/migrate/20230125113130_set_default_on_post_related_links.rb
@@ -1,0 +1,5 @@
+class SetDefaultOnPostRelatedLinks < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :posts, :related_links, from: nil, to: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_25_094914) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_25_113130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,7 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_094914) do
     t.bigint "project_id", null: false
     t.string "slug"
     t.json "ordered_image_ids", default: []
-    t.text "related_links"
+    t.text "related_links", default: ""
     t.index ["project_id", "slug"], name: "index_posts_on_project_id_and_slug", unique: true
     t.index ["project_id"], name: "index_posts_on_project_id"
   end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -7,7 +7,7 @@
 #  ordered_image_ids :json
 #  published         :boolean
 #  published_at      :date
-#  related_links     :text
+#  related_links     :text             default("")
 #  slug              :string
 #  title             :string
 #  created_at        :datetime         not null


### PR DESCRIPTION
- Add missing aria markup from https://github.com/design-history/design-history/pull/171/files#r1086515043
- Change database default to `''`
- Rename it to "Related content" in the view
- Don't display the related links section unless it's present