### PR TITLE
Add related links to projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,6 +53,12 @@ class ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:title, :subdomain, :description, :theme)
+    params.require(:project).permit(
+      :title,
+      :subdomain,
+      :description,
+      :theme,
+      :related_links
+    )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,16 +2,17 @@
 #
 # Table name: projects
 #
-#  id          :bigint           not null, primary key
-#  description :string
-#  owner_type  :string           not null
-#  password    :string
-#  subdomain   :string
-#  theme       :string           default("dh"), not null
-#  title       :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  owner_id    :bigint           not null
+#  id            :bigint           not null, primary key
+#  description   :string
+#  owner_type    :string           not null
+#  password      :string
+#  related_links :text             default("")
+#  subdomain     :string
+#  theme         :string           default("dh"), not null
+#  title         :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  owner_id      :bigint           not null
 #
 # Indexes
 #

--- a/app/views/app/index.html.erb
+++ b/app/views/app/index.html.erb
@@ -27,4 +27,16 @@
       <% end %>
     </ol>
   <% end %>
+
+  <%= govuk_one_third do %>
+    <% if @project.related_links.present? %>
+      <nav class="app-related-links" role="navigation"
+           aria-labelledby="related-content">
+        <h2 class="app-related-links__main-heading" id="related-content">
+          Related content
+        </h2>
+        <%= GovukMarkdown.render(@project.related_links).html_safe %>
+      </nav>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -29,6 +29,10 @@
           class: 'govuk-label govuk-label--s'
         }
       %>
+      <%= f.govuk_text_area :related_links, rows: 4,
+        label: { text: 'Related content', size: 's' },
+        hint: { text: 'Use markdown for links',
+                class: 'govuk-hint govuk-!-font-size-16' } %>
 
       <% themes = [
         OpenStruct.new(id: 'gov', name: 'UK Government'),

--- a/db/migrate/20230125131201_add_related_links_to_projects.rb
+++ b/db/migrate/20230125131201_add_related_links_to_projects.rb
@@ -1,0 +1,5 @@
+class AddRelatedLinksToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :related_links, :text, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_25_113130) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_25_131201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -81,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_113130) do
     t.string "owner_type", null: false
     t.bigint "owner_id", null: false
     t.string "theme", default: "dh", null: false
+    t.text "related_links", default: ""
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
   end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,16 +2,17 @@
 #
 # Table name: projects
 #
-#  id          :bigint           not null, primary key
-#  description :string
-#  owner_type  :string           not null
-#  password    :string
-#  subdomain   :string
-#  theme       :string           default("dh"), not null
-#  title       :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  owner_id    :bigint           not null
+#  id            :bigint           not null, primary key
+#  description   :string
+#  owner_type    :string           not null
+#  password      :string
+#  related_links :text             default("")
+#  subdomain     :string
+#  theme         :string           default("dh"), not null
+#  title         :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  owner_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/system/related_links_spec.rb
+++ b/spec/system/related_links_spec.rb
@@ -4,13 +4,20 @@ RSpec.describe "Related links" do
   it "can be edited" do
     given_i_am_signed_in
     when_i_visit_my_project
-    then_i_see_the_edit_post_link
+    then_i_see_the_change_details_link
+
+    when_i_click_on_change_details
+    and_edit_the_project_related_links
+    then_the_project_is_updated
 
     when_i_click_on_the_edit_post_link
-    and_edit_the_related_links_section
+    and_edit_the_post_related_links
     then_the_post_is_updated
 
     when_i_visit_my_post
+    then_i_see_my_related_links
+
+    when_i_visit_my_design_history
     then_i_see_my_related_links
   end
 
@@ -27,18 +34,32 @@ RSpec.describe "Related links" do
     visit project_path(@project)
   end
 
-  def then_i_see_the_edit_post_link
-    expect(page).to have_link(@first_post.title)
+  def then_i_see_the_change_details_link
+    expect(page).to have_link("Change details")
+  end
+
+  def when_i_click_on_change_details
+    click_link "Change details"
+  end
+
+  def and_edit_the_project_related_links
+    fill_in "project[related_links]",
+            with: "[Related markdown link](https://gov.uk)"
+    click_button "Save"
   end
 
   def when_i_click_on_the_edit_post_link
     click_link @first_post.title
   end
 
-  def and_edit_the_related_links_section
-    @content = "[Related markdown link](https://gov.uk)"
-    fill_in "post[related_links]", with: @content
+  def and_edit_the_post_related_links
+    fill_in "post[related_links]",
+            with: "[Related markdown link](https://gov.uk)"
     click_button "Save"
+  end
+
+  def then_the_project_is_updated
+    expect(page).to have_content("Success")
   end
 
   def then_the_post_is_updated
@@ -52,5 +73,9 @@ RSpec.describe "Related links" do
 
   def then_i_see_my_related_links
     expect(page).to have_link "Related markdown link"
+  end
+
+  def when_i_visit_my_design_history
+    click_link @project.title, match: :first
   end
 end


### PR DESCRIPTION
Allows users to add a related content sidebar to design histories that shows up on the home page.

Closes  #161.

### After

![image](https://user-images.githubusercontent.com/1650875/214581734-102e77a4-e260-4917-aa22-ed42dcb55aff.png)
