### PR TITLE
Update hint for project related links

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -31,8 +31,8 @@
       %>
       <%= f.govuk_text_area :related_links, rows: 4,
         label: { text: 'Related content', size: 's' },
-        hint: { text: 'Use markdown for links',
-                class: 'govuk-hint govuk-!-font-size-16' } %>
+        hint: { text: 'Use markdown for links. These will appear in the
+                       sidebar' } %>
 
       <% themes = [
         OpenStruct.new(id: 'gov', name: 'UK Government'),


### PR DESCRIPTION
The class wasn't intentional. Also update the hint text.

See https://github.com/design-history/design-history/pull/175#discussion_r1086702164.


### After

![image](https://user-images.githubusercontent.com/1650875/215093348-540dd778-9f89-4ce0-a565-3afa438bd7d5.png)
