### PR TITLE
Validate that post slugs are unique to the project

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -39,6 +39,9 @@ class Post < ApplicationRecord
             },
             format: {
               with: /\A[a-z0-9-]+\z/
+            },
+            uniqueness: {
+              scope: :project
             }
   validates :published_at, presence: true, if: -> { published == true }
 

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -49,6 +49,7 @@ en:
               too_long: Enter a slug that is less than 50 characters long
               invalid: Enter a slug in the correct format, like
                 how-we-chose-our-service-name
+              taken: Enter a slug that hasn’t been used on another post
             body:
               blank: Enter a body
             published_at:


### PR DESCRIPTION
Without this, entering a duplicate slug violates an uniqueness constraint on the DB and throws a 500 error.

<img width="712" alt="image" src="https://user-images.githubusercontent.com/23801/217604860-1789827d-5dea-4f6f-80f1-5bfcfcfd9101.png">

Not sure whether the content is 👍  or 👎 .