### PR TITLE
Prevent inline images from overflowing

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -64,3 +64,10 @@ $govuk-button-background-colour: $app-button-colour;
 .govuk-table__head .govuk-table__cell {
   font-weight: bold;
 }
+
+.app-markdown {
+  .govuk-body-m img {
+    max-width: 100%;
+    outline: 1px solid rgba(177, 180, 182, 0.5);
+  }
+}

--- a/app/views/app/show.html.erb
+++ b/app/views/app/show.html.erb
@@ -26,7 +26,9 @@
   </div>
 
   <%= govuk_two_thirds do %>
-    <%= GovukMarkdown.render(@post.body).html_safe %>
+    <div class="app-markdown">
+      <%= GovukMarkdown.render(@post.body).html_safe %>
+    </div>
 
     <%= render "shared/screenshots", post: @post if @post.ordered_images.any? %>
   <% end %>


### PR DESCRIPTION
Fixes:

![screenshot_2023-03-02_at_11 35 28_720](https://user-images.githubusercontent.com/319055/222419929-606db9ad-79f3-4ffe-b037-8eedeafa3290.png)
