### PR TITLE
Design tweaks

### DIFF
--- a/app/controllers/post_images_controller.rb
+++ b/app/controllers/post_images_controller.rb
@@ -6,20 +6,18 @@ class PostImagesController < ApplicationController
 
   def up
     @post.ordered_image_move_up!(@image)
-    redirect_to edit_project_post_path(@project, @post),
-                notice: "Image was successfully moved"
+    redirect_to edit_project_post_path(@project, @post), notice: "Image moved"
   end
 
   def down
     @post.ordered_image_move_down!(@image)
-    redirect_to edit_project_post_path(@project, @post),
-                notice: "Image was successfully moved"
+    redirect_to edit_project_post_path(@project, @post), notice: "Image moved"
   end
 
   def create
     if @post.update(create_params)
       redirect_to edit_project_post_path(@project, @post),
-                  notice: "Images were successfully uploaded"
+                  notice: "Images uploaded"
     else
       render "post/edit", status: :unprocessable_entity
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,8 +32,20 @@ class PostsController < ApplicationController
   # PATCH/PUT /posts/1
   def update
     if @post.update(post_params)
-      redirect_to edit_project_post_path(@project, @post),
-                  notice: "Changes saved"
+      if @post.published?
+        body =
+          helpers.govuk_link_to "View post",
+                                app_post_url(
+                                  @post.to_param,
+                                  host: Rails.application.config.app_domain,
+                                  subdomain: @project.subdomain
+                                )
+        notice = { title: "Changes saved", body: }
+      else
+        notice = "Changes saved"
+      end
+
+      redirect_to edit_project_post_path(@project, @post), notice:
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,7 +23,7 @@ class PostsController < ApplicationController
 
     if @post.save
       redirect_to edit_project_post_path(@project, @post),
-                  notice: "Post was successfully created"
+                  notice: "Post created"
     else
       render :new, status: :unprocessable_entity
     end
@@ -33,7 +33,7 @@ class PostsController < ApplicationController
   def update
     if @post.update(post_params)
       redirect_to edit_project_post_path(@project, @post),
-                  notice: "Post was successfully updated"
+                  notice: "Changes saved"
     else
       render :edit, status: :unprocessable_entity
     end
@@ -42,7 +42,7 @@ class PostsController < ApplicationController
   # DELETE /posts/1
   def destroy
     @post.destroy!
-    redirect_to posts_url, notice: "Post was successfully destroyed"
+    redirect_to posts_url, notice: "Post deleted"
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -28,7 +28,7 @@ class TeamsController < ApplicationController
     @add_user_form = AddUserForm.new(add_user_params)
     @add_user_form.team = @team
     if @add_user_form.save
-      redirect_to @team, notice: "User was successfully added"
+      redirect_to @team, notice: "User added"
     else
       render :show, status: :unprocessable_entity
     end

--- a/app/views/layouts/_banners.html.erb
+++ b/app/views/layouts/_banners.html.erb
@@ -3,7 +3,12 @@
     <%= govuk_two_thirds do %>
       <%= govuk_notification_banner(title_text: "Success",
                                     success: true) do |nb| %>
-        <% nb.heading(text: notice) %>
+        <% if notice.is_a?(String) %>
+          <% nb.heading(text: notice) %>
+        <% else %>
+          <% nb.heading(text: notice["title"]) %>
+          <%= notice["body"].html_safe %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -44,7 +44,7 @@
           <div class="govuk-footer__meta-custom">
             © 2022–<%= Time.now.year %>. Built with
             <a class="govuk-footer__link"
-               href="https://this.designhistory.app">
+               href="https://www.designhistory.io">
               Design history</a>.
             <a class="govuk-footer__link"
                href="https://github.com/design-history/design-history/">

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -42,13 +42,22 @@
         footer.meta do %>
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
           <div class="govuk-footer__meta-custom">
-            © 2022–<%= Time.now.year %>. Built with
-            <a class="govuk-footer__link"
-               href="https://www.designhistory.io">
-              Design history</a>.
-            <a class="govuk-footer__link"
-               href="https://github.com/design-history/design-history/">
-              Source code on GitHub</a>.
+            <% unless is_admin? %>
+              <p class="govuk-body-s">
+                <a class="govuk-footer__link"
+                  href="https://www.designhistory.io/sign-in">
+                  Sign in</a>
+              </p>
+            <% end %>
+            <p class="govuk-body-s govuk-footer__licence-description">
+              © 2022–<%= Time.now.year %> Built with
+              <a class="govuk-footer__link"
+                href="https://www.designhistory.io">
+                Design history</a>.
+              <a class="govuk-footer__link"
+                href="https://github.com/design-history/design-history/">
+                Source code on GitHub</a>.
+            </p>
           </div>
         </div>
       <% end; end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -32,8 +32,3 @@
     <%= render "form", project: @project, post: @post %>
   </div>
 </div>
-
-<div>
-  <%= govuk_link_to "Show this post", [@project, @post] %> |
-  <%= govuk_link_to "Back to posts", project_posts_path(@project) %>
-</div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -15,10 +15,19 @@
           </li>
         <% end %>
       </ul>
+      <p>
+        <%= govuk_button_link_to "New design history", new_project_path %>
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        You don’t have any design histories yet.
+      </p>
+      <p>You can either:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>create your first design history</li>
+        <li>ask a team member to add you to an existing design history</li>
+      </ul>
+      <%= govuk_button_link_to "Create your first design history", new_project_path %>
     <% end %>
-
-    <p>
-      <%= govuk_button_link_to "New design history", new_project_path %>
-    </p>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     root to: "pages#landing"
 
     get "/start", to: "pages#start"
+    get "/sign-in", to: redirect("/users/sign_in")
 
     devise_for :users
 

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe "Posts" do
 
     when_i_submit_my_post_details
     then_i_see_the_edit_post_page
+
+    when_i_publish_my_post
+    then_i_see_the_edit_post_page
+    and_i_see_a_view_post_link
   end
 
   private
@@ -38,13 +42,29 @@ RSpec.describe "Posts" do
   end
 
   def when_i_submit_my_post_details
+    @slug = Faker::Internet.slug.gsub("_", "-")
     fill_in "post[title]", with: Faker::Company.bs.capitalize
-    fill_in "post[slug]", with: Faker::Internet.slug.gsub("_", "-")
+    fill_in "post[slug]", with: @slug
     fill_in "post[body]", with: Faker::Markdown.sandwich
+    click_button "Save"
+  end
+
+  def when_i_publish_my_post
+    fill_in "post[published_at(3i)]", with: "1"
+    fill_in "post[published_at(2i)]", with: "1"
+    fill_in "post[published_at(1i)]", with: "2001"
+    find('label[for*="post-published"]').click
     click_button "Save"
   end
 
   def then_i_see_the_edit_post_page
     expect(page).to have_content "Editing post"
+  end
+
+  def and_i_see_a_view_post_link
+    expect(page).to have_selector(
+      "a[href*='#{@project.subdomain}'][href*='#{@slug}']",
+      text: "View post"
+    )
   end
 end

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe "Projects" do
   end
 
   def then_i_see_a_new_project_button
-    expect(page).to have_link "New design history"
+    expect(page).to have_link "Create your first design history"
   end
 
   def when_i_click_the_new_project_button
-    click_link "New design history"
+    click_link "Create your first design history"
   end
 
   def then_i_see_the_new_project_form


### PR DESCRIPTION
Fixes #196 by putting a Sign in link in the footer of the design history and adding a `/sign-in` slug
Fixes #192 and fixes #190 by removing the broken link and adding "View post" to success banner
Improves the new user journey

<img width="718" alt="Screenshot 2023-03-02 at 16 29 59" src="https://user-images.githubusercontent.com/319055/222491346-c4db0769-6572-4748-938c-155fa2ceacb7.png">

<img width="681" alt="Screenshot 2023-03-02 at 14 54 55" src="https://user-images.githubusercontent.com/319055/222491214-af5b606a-9023-44fa-a488-37dc1a119918.png">

