### PR TITLE
Better image title generation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,6 +35,7 @@ module ApplicationHelper
   def humanize_image_title(image)
     extension = File.extname(image.filename.to_s)
     filename = image.filename.to_s.chomp extension
+    filename = filename.sub(/\A\d{2}-/, "").gsub("-", "_")
     filename.humanize
   end
 


### PR DESCRIPTION
Numbers can be used in filenames to determine ordering before uploading.

- Remove any numbering at the beginning of the filename
- Replace `-` with `_` for better humanizing