### PR TITLE
Add an admin panel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.1.2"
 
+gem "avo"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", require: false
 gem "cssbundling-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_link_to (1.0.5)
+      actionpack
+      addressable
     activejob (7.0.4.2)
       activesupport (= 7.0.4.2)
       globalid (>= 0.3.6)
@@ -72,6 +75,20 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
+    avo (2.27.1)
+      actionview (>= 6.0)
+      active_link_to
+      activerecord (>= 6.0)
+      addressable
+      docile
+      dry-initializer
+      httparty
+      inline_svg
+      meta-tags
+      pagy
+      turbo-rails
+      view_component
+      zeitwerk (>= 2.6.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.714.0)
     aws-sdk-core (3.170.0)
@@ -125,6 +142,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    dry-initializer (3.1.1)
     e2mmap (0.1.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
@@ -165,11 +184,17 @@ GEM
       rails (>= 6.0.0)
     html-attributes-utils (0.9.2)
       activesupport (>= 6.1.4.4)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    inline_svg (1.8.0)
+      activesupport (>= 3.0)
+      nokogiri (>= 1.6)
     io-console (0.6.0)
     irb (1.6.2)
       reline (>= 0.3.0)
@@ -195,11 +220,14 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    meta-tags (2.18.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.6.0)
+    multi_xml (0.6.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -404,6 +432,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  avo
   aws-sdk-s3
   bootsnap
   cssbundling-rails

--- a/app/avo/resources/user_resource.rb
+++ b/app/avo/resources/user_resource.rb
@@ -1,0 +1,20 @@
+class UserResource < Avo::BaseResource
+  self.title = :email
+  self.includes = []
+  # self.search_query = -> do
+  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+  # end
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :email, as: :text
+  field :sign_in_count, as: :number
+  field :current_sign_in_at, as: :date_time
+  field :last_sign_in_at, as: :date_time
+  field :current_sign_in_ip, as: :text
+  field :last_sign_in_ip, as: :text
+  field :team_id, as: :number
+  field :admin, as: :boolean
+  # field :team, as: :belongs_to
+  # add fields here
+end

--- a/app/controllers/avo/users_controller.rb
+++ b/app/controllers/avo/users_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::UsersController < Avo::ResourcesController
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  admin                  :boolean          default(FALSE), not null
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :string
 #  email                  :string           default(""), not null

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -16,7 +16,7 @@ Avo.configure do |config|
   end
 
   ## == Authentication ==
-  # config.current_user_method = {}
+  config.current_user_method = :current_user
   # config.authenticate_with do
   # end
 

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -1,0 +1,108 @@
+# For more information regarding these settings check out our docs https://docs.avohq.io
+Avo.configure do |config|
+  ## == Routing ==
+  config.root_path = "/avo"
+
+  # Where should the user be redirected when visting the `/avo` url
+  # config.home_path = nil
+
+  ## == Licensing ==
+  config.license = "community" # change this to 'pro' when you add the license key
+  # config.license_key = ENV['AVO_LICENSE_KEY']
+
+  ## == Set the context ==
+  config.set_context do
+    # Return a context object that gets evaluated in Avo::ApplicationController
+  end
+
+  ## == Authentication ==
+  # config.current_user_method = {}
+  # config.authenticate_with do
+  # end
+
+  ## == Authorization ==
+  # config.authorization_methods = {
+  #   index: 'index?',
+  #   show: 'show?',
+  #   edit: 'edit?',
+  #   new: 'new?',
+  #   update: 'update?',
+  #   create: 'create?',
+  #   destroy: 'destroy?',
+  # }
+  # config.raise_error_on_missing_policy = false
+  # config.authorization_client = :pundit
+
+  ## == Localization ==
+  # config.locale = 'en-US'
+
+  ## == Resource options ==
+  # config.resource_controls_placement = :right
+  # config.model_resource_mapping = {}
+  # config.default_view_type = :table
+  # config.per_page = 24
+  # config.per_page_steps = [12, 24, 48, 72]
+  # config.via_per_page = 8
+  # config.id_links_to_resource = false
+  # config.cache_resources_on_index_view = true
+  ## permanent enable or disable cache_resource_filters, default value is false
+  # config.cache_resource_filters = false
+  ## provide a lambda to enable or disable cache_resource_filters per user/resource.
+  # config.cache_resource_filters = ->(current_user:, resource:) { current_user.cache_resource_filters?}
+
+  ## == Customization ==
+  # config.app_name = 'Avocadelicious'
+  # config.timezone = 'UTC'
+  # config.currency = 'USD'
+  # config.hide_layout_when_printing = false
+  # config.full_width_container = false
+  # config.full_width_index_view = false
+  # config.search_debounce = 300
+  # config.view_component_path = "app/components"
+  # config.display_license_request_timeout_error = true
+  # config.disabled_features = []
+  # config.resource_controls = :right
+  # config.tabs_style = :tabs # can be :tabs or :pills
+  # config.buttons_on_form_footers = true
+  # config.field_wrapper_layout = true
+
+  ## == Branding ==
+  # config.branding = {
+  #   colors: {
+  #     background: "248 246 242",
+  #     100 => "#CEE7F8",
+  #     400 => "#399EE5",
+  #     500 => "#0886DE",
+  #     600 => "#066BB2",
+  #   },
+  #   chart_colors: ["#0B8AE2", "#34C683", "#2AB1EE", "#34C6A8"],
+  #   logo: "/avo-assets/logo.png",
+  #   logomark: "/avo-assets/logomark.png",
+  #   placeholder: "/avo-assets/placeholder.svg",
+  #   favicon: "/avo-assets/favicon.ico"
+  # }
+
+  ## == Breadcrumbs ==
+  # config.display_breadcrumbs = true
+  # config.set_initial_breadcrumbs do
+  #   add_breadcrumb "Home", '/avo'
+  # end
+
+  ## == Menus ==
+  # config.main_menu = -> {
+  #   section "Dashboards", icon: "dashboards" do
+  #     all_dashboards
+  #   end
+
+  #   section "Resources", icon: "resources" do
+  #     all_resources
+  #   end
+
+  #   section "Tools", icon: "tools" do
+  #     all_tools
+  #   end
+  # }
+  # config.profile_menu = -> {
+  #   link "Profile", path: "/avo/profile", icon: "user-circle"
+  # }
+end

--- a/config/locales/avo.en.yml
+++ b/config/locales/avo.en.yml
@@ -1,0 +1,124 @@
+---
+en:
+  avo:
+    action_ran_successfully: Action ran successfully!
+    actions: Actions
+    and_x_other_resources: and %{count} other resources
+    are_you_sure: Are you sure?
+    are_you_sure_detach_item: Are you sure you want to detach this %{item}.
+    are_you_sure_you_want_to_run_this_option: Are you sure you want to run this action?
+    attach: Attach
+    attach_and_attach_another: Attach & Attach another
+    attach_item: Attach %{item}
+    attachment_class_attached: "%{attachment_class} attached."
+    attachment_class_detached: "%{attachment_class} detached."
+    attachment_destroyed: Attachment destroyed
+    cancel: Cancel
+    choose_a_country: Choose a country
+    choose_an_option: Choose an option
+    choose_item: Choose %{item}
+    clear_value: Clear value
+    click_to_reveal_filters: Click to reveal filters
+    confirm: Confirm
+    create_new_item: Create new %{item}
+    dashboard: Dashboard
+    dashboards: Dashboards
+    delete: delete
+    delete_file: Delete file
+    delete_item: Delete %{item}
+    detach_item: detach %{item}
+    details: details
+    download: Download
+    download_file: Download file
+    download_item: Download %{item}
+    edit: edit
+    edit_item: edit %{item}
+    empty_dashboard_message: Add cards to this dashboard
+    failed: Failed
+    failed_to_find_attachment: Failed to find attachment
+    failed_to_load: Failed to load
+    field_translations:
+      file:
+        one: file
+        other: files
+        zero: files
+      people:
+        one: peep
+        other: peeps
+        zero: peeps
+    filter_by: Filter by
+    filters: Filters
+    go_back: Go back
+    grid_view: Grid view
+    hide_content: Hide content
+    home: Home
+    key_value_field:
+      add_row: Add row
+      delete_row: Delete row
+      key: Key
+      value: Value
+    list_is_empty: List is empty
+    loading: Loading
+    more: More
+    new: new
+    next_page: Next page
+    no_cards_present: No cards present
+    no_item_found: No record found
+    no_options_available: No options available
+    no_related_item_found: No related record found
+    not_authorized: You are not authorized to perform this action.
+    number_of_items:
+      one: one %{item}
+      other: "%{count} %{item}"
+      zero: no %{item}
+    oops_nothing_found: Oops! Nothing found...
+    order:
+      higher: Move record higher
+      lower: Move record lower
+      reorder_record: Reorder record
+      to_bottom: Move record to bottom
+      to_top: Move record to top
+    per_page: Per page
+    prev_page: Previous page
+    remove_selection: Remove selection
+    reset_filters: Reset filters
+    resource_created: Record created
+    resource_destroyed: Record destroyed
+    resource_translations:
+      team_members:
+        one: team member
+        other: team memberz
+        zero: team memberz
+      user:
+        one: user
+        other: users
+        zero: users
+    resource_updated: Record updated
+    resources: Resources
+    run: Run
+    save: Save
+    search:
+      cancel_button: Cancel
+      placeholder: Search
+    select_all: Select all
+    select_all_matching: Select all matching
+    select_item: Select item
+    show_content: Show content
+    sign_out: Sign out
+    switch_to_view: Switch to %{view_type} view
+    table_view: Table view
+    tools: Tools
+    type_to_search: Type to search.
+    unauthorized: Unauthorized
+    undo: undo
+    view: View
+    view_item: view %{item}
+    was_successfully_created: was successfully created
+    was_successfully_updated: was successfully updated
+    x_items_more:
+      one: one more item
+      other: "%{count} more items"
+      zero: no more items
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> records selected on this page from a total of <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> records selected from all pages
+    you_missed_something_check_form: You might have missed something. Please check the form.

--- a/config/locales/avo.fr.yml
+++ b/config/locales/avo.fr.yml
@@ -1,0 +1,120 @@
+---
+fr:
+  avo:
+    action_ran_successfully: L'action s'est exécutée avec succès !
+    actions: Actions
+    and_x_other_resources: et %{count} autres ressources
+    are_you_sure: Êtes-vous sûr ?
+    are_you_sure_detach_item: Êtes-vous sûr de vouloir détacher %{item}.
+    are_you_sure_you_want_to_run_this_option: Etes-vous sûr de vouloir exécuter cette action ?
+    attach: Attacher
+    attach_and_attach_another: joindre et joindre un autre
+    attach_item: Attacher %{item}
+    attachment_class_attached: "%{attachment_class} attaché."
+    attachment_class_detached: "%{attachment_class} détaché."
+    attachment_destroyed: Pièce jointe détruite
+    cancel: Annuler
+    choose_a_country: Sélectionnez un pays
+    choose_an_option: Sélectionnez une option
+    choose_item: Choisir %{item}
+    clear_value: Effacer la valeur
+    click_to_reveal_filters: Cliquez pour révéler les filtres
+    confirm: Confirmer
+    create_new_item: Créer un nouveau %{item}
+    dashboard: Tableau de bord
+    dashboards: Tableaux de bord
+    delete: supprimer
+    delete_file: Supprimer le fichier
+    delete_item: Supprimer %{item}
+    detach_item: détacher %{item}
+    details: détails
+    download: Télécharger
+    download_file: Télécharger le fichier
+    download_item: Télécharger %{item}
+    edit: éditer
+    edit_item: éditer %{item}
+    empty_dashboard_message: Ajouter des cartes à ce tableau de bord
+    failed: Échec
+    failed_to_find_attachment: Impossible de trouver la pièce jointe
+    failed_to_load: Impossible de charger
+    field_translations:
+      file:
+        one: fichier
+        other: fichiers
+        zero: fichier
+      people:
+        one: personne
+        other: personnes
+        zero: personne
+    filter_by: Filtrer par
+    filters: Filtres
+    go_back: Retourner en arrière
+    grid_view: Vue grille
+    hide_content: Cacher le contenu
+    home: Accueil
+    key_value_field:
+      add_row: Ajouter une ligne
+      delete_row: Supprimer une ligne
+      key: Clé
+      value: Valeur
+    list_is_empty: La liste est vide
+    loading: Chargement
+    more: Plus
+    new: Nouveau
+    next_page: Page suivante
+    no_cards_present: Aucune carte présente
+    no_item_found: Enregistrement non trouvé
+    no_options_available: Aucune option disponible
+    no_related_item_found: Enregistrement connexe introuvable
+    not_authorized: Vous n'êtes pas autorisé à effectuer cette action.
+    number_of_items:
+      one: un %{item}
+      other: "%{count} %{item}"
+      zero: aucun %{item}
+    oops_nothing_found: Oups ! Rien n'a été trouvé...
+    order:
+      higher: Déplacer plus haut
+      lower: Déplacer plus bas
+      reorder_record: Réorganiser
+      to_bottom: Déplacer tout en bas
+      to_top: Déplacer tout en haut
+    per_page: Par page
+    prev_page: Page précédente
+    remove_selection: Supprimer la sélection
+    reset_filters: Réinitialiser les filtres
+    resource_created: Ressource créee
+    resource_destroyed: Ressource détruite
+    resource_translations:
+      user:
+        one: utilisateurs
+        other: utilisateurs
+        zero: utilisateur
+    resource_updated: Ressource mise à jour
+    resources: Ressources
+    run: Exécuter
+    save: Enregistrer
+    search:
+      cancel_button: Annuler
+      placeholder: Rechercher
+    select_all: Sélectionner tout sur la page
+    select_all_matching: Sélectionner toutes les correspondances
+    select_item: Sélectionnez un élément
+    show_content: Afficher le contenu
+    sign_out: Se déconnecter
+    switch_to_view: Passez à la vue %{view_type}
+    table_view: Vue table
+    tools: Outils
+    type_to_search: Type à rechercher.
+    unauthorized: Non autorisé
+    undo: annuler
+    view: Vue
+    view_item: voir %{item}
+    was_successfully_created: a été créé avec succès
+    was_successfully_updated: a été mis à jour avec succès
+    x_items_more:
+      one: un élément de plus
+      other: "%{count} éléments en plus"
+      zero: aucun élément supplémentaire
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> enregistrements sélectionnés sur cette page sur un total de <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> enregistrements sélectionnés dans toutes les pages
+    you_missed_something_check_form: Vous avez peut-être oublié quelque chose. Veuillez vérifier le formulaire

--- a/config/locales/avo.nb.yml
+++ b/config/locales/avo.nb.yml
@@ -1,0 +1,120 @@
+---
+nb:
+  avo:
+    action_ran_successfully: Suksess!
+    actions: Handlinger
+    and_x_other_resources: og %{count} andre ressurser
+    are_you_sure: Er du sikker?
+    are_you_sure_detach_item: Er du sikker på at du vil koble fra %{item}.
+    are_you_sure_you_want_to_run_this_option: Er du sikker?
+    attach: Legg til
+    attach_and_attach_another: Legg til & Legg til ny
+    attach_item: Legg til %{item}
+    attachment_class_attached: "%{attachment_class} lagt til."
+    attachment_class_detached: "%{attachment_class} fjernet."
+    attachment_destroyed: Vedlett slettet
+    cancel: Avbryt
+    choose_a_country: Velg et land
+    choose_an_option: Velg et alternativ
+    choose_item: Velge %{item}
+    clear_value: Nullstill verdi
+    click_to_reveal_filters: Vis filter
+    confirm: Bekreft
+    create_new_item: Lag ny %{item}
+    dashboard: Dashboard
+    dashboards: Dashboards
+    delete: slett
+    delete_file: Slett fil
+    delete_item: Slett %{item}
+    detach_item: koble fra %{item}
+    details: detaljer
+    download: Last ned
+    download_file: Last ned fil
+    download_item: Last ned %{item}
+    edit: endre
+    edit_item: endre %{item}
+    empty_dashboard_message: Legg til kort i dette dashbordet
+    failed: Feilet
+    failed_to_find_attachment: Fant ikke vedlegg
+    failed_to_load: Lasting feilet
+    field_translations:
+      file:
+        one: fil
+        other: filer
+        zero: filer
+      people:
+        one: person
+        other: personer
+        zero: personer
+    filter_by: Filtrer etter
+    filters: Filter
+    go_back: Gå tilbake
+    grid_view: Grid visning
+    hide_content: Skjul innhold
+    home: Hjem
+    key_value_field:
+      add_row: Legg til rad
+      delete_row: Slett rad
+      key: Nøkkel
+      value: Verdi
+    list_is_empty: Listen er tom
+    loading: Laster
+    more: Mer
+    new: ny
+    next_page: Neste side
+    no_cards_present: Ingen kort til stede
+    no_item_found: Ingen funnet
+    no_options_available: Ingen tilgjengelige alternativer
+    no_related_item_found: Ingen relaterte funnet
+    not_authorized: Du er ikke autorisert til å gjøre denne handlingen.
+    number_of_items:
+      one: en %{item}
+      other: "%{count} %{item}"
+      zero: ingen %{item}
+    oops_nothing_found: Oops! Ingen ting funnet...
+    order:
+      higher: Flytt elementet høyere
+      lower: Flytt elementet lavere
+      reorder_record: Sorter elementer
+      to_bottom: Flytt elementet til bunnen
+      to_top: Flytt elementet til toppen
+    per_page: Per side
+    prev_page: Forrige side
+    remove_selection: Fjern valg
+    reset_filters: Nullstill filter
+    resource_created: Ressurs generert
+    resource_destroyed: Ressurs slettet
+    resource_translations:
+      user:
+        one: bruker
+        other: brukere
+        zero: brukere
+    resource_updated: Ressurs oppdatert
+    resources: Ressurser
+    run: Kjør
+    save: Lagre
+    search:
+      cancel_button: Avbryt
+      placeholder: Søk
+    select_all: Velg alle
+    select_all_matching: Velg alle samsvarende
+    select_item: Velg
+    show_content: Vis innhold
+    sign_out: Logg ut
+    switch_to_view: Bytt til %{view_type} vis
+    table_view: Tabell visning
+    tools: Redskapene
+    type_to_search: Søk.
+    unauthorized: Ikke autorisert
+    undo: angre
+    view: Vis
+    view_item: vis %{item}
+    was_successfully_created: ble opprettet
+    was_successfully_updated: ble oppdatert
+    x_items_more:
+      one: ett element til
+      other: "%{count} flere elementer"
+      zero: ingen flere elementer
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> poster valgt på denne siden fra totalt <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> poster valgt fra alle sider
+    you_missed_something_check_form: Her mangler du noe. Vennligst sjekk skjemaet.

--- a/config/locales/avo.nn.yml
+++ b/config/locales/avo.nn.yml
@@ -1,0 +1,120 @@
+---
+nn:
+  avo:
+    action_ran_successfully: Suksess!
+    actions: Handlingar
+    and_x_other_resources: og %{count} andre ressursar
+    are_you_sure: Er du sikker?
+    are_you_sure_detach_item: Er du sikker på at du vil koble frå %{item}.
+    are_you_sure_you_want_to_run_this_option: Er du sikker?
+    attach: Legg til
+    attach_and_attach_another: Legg til & Legg til ny
+    attach_item: Legg til %{item}
+    attachment_class_attached: "%{attachment_class} lagt til."
+    attachment_class_detached: "%{attachment_class} fjerna."
+    attachment_destroyed: Vedlegg sletta
+    cancel: Avbryt
+    choose_a_country: Vel eit land
+    choose_an_option: Vel eit alternativ
+    choose_item: Vel %{item}
+    clear_value: Nullstill verdi
+    click_to_reveal_filters: Vis filter
+    confirm: Stadfest
+    create_new_item: Lag ny %{item}
+    dashboard: Dashboard
+    dashboards: Dashboards
+    delete: slett
+    delete_file: Slett fil
+    delete_item: Slett %{item}
+    detach_item: koble frå %{item}
+    details: detaljar
+    download: Last ned
+    download_file: Last ned fil
+    download_item: Last ned %{item}
+    edit: endre
+    edit_item: endre %{item}
+    empty_dashboard_message: Legg til kort i dette dashbordet
+    failed: Feila
+    failed_to_find_attachment: Fann ikkje vedlegg
+    failed_to_load: Lasting feila
+    field_translations:
+      file:
+        one: fil
+        other: filer
+        zero: filer
+      people:
+        one: person
+        other: personar
+        zero: personar
+    filter_by: Filtrer etter
+    filters: Filter
+    go_back: Gå tilbake
+    grid_view: Gridvisning
+    hide_content: Skjul innhald
+    home: Heim
+    key_value_field:
+      add_row: Legg til rad
+      delete_row: Slett rad
+      key: Nøkkel
+      value: Verdi
+    list_is_empty: Lista er tom
+    loading: Lastar
+    more: Meir
+    new: ny
+    next_page: Neste side
+    no_cards_present: Ingen kort til stades
+    no_item_found: Fann ingen
+    no_options_available: Ingen tilgjengelege alternativ
+    no_related_item_found: Fann ingen relaterte
+    not_authorized: Du er ikkje autorisert til å gjere denne handlinga.
+    number_of_items:
+      one: en %{item}
+      other: "%{count} %{item}"
+      zero: ingen %{item}
+    oops_nothing_found: Oops! Fann ikkje noko...
+    order:
+      higher: Flytt elementet opp
+      lower: Flytt elementet ned
+      reorder_record: Sorter element
+      to_bottom: Flytt elementet til botnen
+      to_top: Flytt elementet til toppen
+    per_page: Per side
+    prev_page: Førre side
+    remove_selection: Fjern val
+    reset_filters: Nullstill filter
+    resource_created: Ressurs generert
+    resource_destroyed: Ressurs sletta
+    resource_translations:
+      user:
+        one: brukar
+        other: brukarar
+        zero: brukarar
+    resource_updated: Ressurs oppdatert
+    resources: Ressursar
+    run: Køyr
+    save: Lagre
+    search:
+      cancel_button: Avbryt
+      placeholder: Søk
+    select_all: Vel alle
+    select_all_matching: Vel alle samsvarende
+    select_item: Vel
+    show_content: Vis innhald
+    sign_out: Logg ut
+    switch_to_view: Bytt til %{view_type} vis
+    table_view: Tabellvisning
+    tools: Reiskapane
+    type_to_search: Søk.
+    unauthorized: Ikkje autorisert
+    undo: angre
+    view: Vis
+    view_item: vis %{item}
+    was_successfully_created: vart oppretta
+    was_successfully_updated: vart oppdatert
+    x_items_more:
+      one: eitt element til
+      other: "%{count} fleire element"
+      zero: ingen fleire element
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> valde postar på denne sida av totalt <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> valde postar frå alle sider
+    you_missed_something_check_form: Her manglar du noko. Ver venleg og sjekk skjemaet.

--- a/config/locales/avo.pt-BR.yml
+++ b/config/locales/avo.pt-BR.yml
@@ -1,0 +1,120 @@
+---
+pt-BR:
+  avo:
+    action_ran_successfully: Ação executada com sucesso!
+    actions: Ações
+    and_x_other_resources: e %{count} outros recursos
+    are_you_sure: Você tem certeza?
+    are_you_sure_detach_item: Você tem certeza que deseja separar este %{item}.
+    are_you_sure_you_want_to_run_this_option: Você tem certeza que deseja executar esta ação?
+    attach: Anexar
+    attach_and_attach_another: Anexar & anexar outro
+    attach_item: Anexar %{item}
+    attachment_class_attached: "%{attachment_class} anexado."
+    attachment_class_detached: "%{attachment_class} separado."
+    attachment_destroyed: Anexo destruído
+    cancel: Cancelar
+    choose_a_country: Escolha um país
+    choose_an_option: Escolha uma opção
+    choose_item: Escolher %{item}
+    clear_value: Limpar valor
+    click_to_reveal_filters: Clique para revelar os filtros
+    confirm: Confirmar
+    create_new_item: Criar novo %{item}
+    dashboard: Painel
+    dashboards: Painéis
+    delete: deletar
+    delete_file: Deletar arquivo
+    delete_item: Deletar %{item}
+    detach_item: separar %{item}
+    details: detalhe
+    download: Baixar
+    download_file: Baixar arquivo
+    download_item: Baixar %{item}
+    edit: editar
+    edit_item: editar %{item}
+    empty_dashboard_message: Adicionar cartões a este painel
+    failed: Falhou
+    failed_to_find_attachment: Falhou ao achar anexo
+    failed_to_load: Falha ao carregar
+    field_translations:
+      file:
+        one: arquivo
+        other: arquivos
+        zero: arquivos
+      people:
+        one: pessoa
+        other: pessoas
+        zero: ninguém
+    filter_by: Filtrar por
+    filters: Filtros
+    go_back: Voltar
+    grid_view: Visualização em grade
+    hide_content: Esconder conteúdo
+    home: Início
+    key_value_field:
+      add_row: Adicionar linha
+      delete_row: Remover linha
+      key: Chave
+      value: Valor
+    list_is_empty: Lista vazia
+    loading: Carregando
+    more: Mais
+    new: novo
+    next_page: Próxima página
+    no_cards_present: Nenhum cartão presente
+    no_item_found: Nenhum registro encontrado
+    no_options_available: Nenhuma opção disponível
+    no_related_item_found: Nenhum registro relacionado encontrado
+    not_authorized: Você não está autorizado à executar essa ação.
+    number_of_items:
+      one: um %{item}
+      other: "%{count} %{item}"
+      zero: sem %{item}
+    oops_nothing_found: Oops! Nada encontrado...
+    order:
+      higher: Mover registro um para cima
+      lower: Mover registro um para baixo
+      reorder_record: Reordenar registro
+      to_bottom: Mover registro para baixo
+      to_top: Mover registro para cima
+    per_page: Por página
+    prev_page: Página anterior
+    remove_selection: Remover seleção
+    reset_filters: Limpar filtros
+    resource_created: Recurso criado
+    resource_destroyed: Recurso destruído
+    resource_translations:
+      user:
+        one: usuário
+        other: usuários
+        zero: usuários
+    resource_updated: Recurso atualizado
+    resources: Recursos
+    run: Executar
+    save: Salvar
+    search:
+      cancel_button: Cancelar
+      placeholder: Procurar
+    select_all: Selecionar tudo
+    select_all_matching: Selecione todas as correspondências
+    select_item: Selecionar item
+    show_content: Mostrar conteúdo
+    sign_out: sair
+    switch_to_view: Alterar para visão %{view_type}
+    table_view: Visualização em tabela
+    tools: Ferramentas
+    type_to_search: Digite para buscar.
+    unauthorized: Não autorizado
+    undo: desfazer
+    view: Visualizar
+    view_item: visualizar %{item}
+    was_successfully_created: foi criado com sucesso
+    was_successfully_updated: foi atualizado com sucesso
+    x_items_more:
+      one: mais um item
+      other: "%{count} mais items"
+      zero: mais nenhum item
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> registros selecionados nesta página de um total de <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> registros selecionados de todas as páginas
+    you_missed_something_check_form: Você pode ter esquecido algo. Por favor, cheque o formulário.

--- a/config/locales/avo.pt.yml
+++ b/config/locales/avo.pt.yml
@@ -1,0 +1,120 @@
+---
+pt:
+  avo:
+    action_ran_successfully: Ação executada com sucesso!
+    actions: Ações
+    and_x_other_resources: e %{count} outros recursos
+    are_you_sure: Tem a certeza?
+    are_you_sure_detach_item: Tem a certeza que deseja separar este %{item}.
+    are_you_sure_you_want_to_run_this_option: Tem a certeza que deseja executar esta ação?
+    attach: Anexar
+    attach_and_attach_another: Anexar & anexar outro
+    attach_item: Anexar %{item}
+    attachment_class_attached: "%{attachment_class} anexado."
+    attachment_class_detached: "%{attachment_class} separado."
+    attachment_destroyed: Anexo destruído
+    cancel: Cancelar
+    choose_a_country: Escolha um país
+    choose_an_option: Escolha uma opção
+    choose_item: Escolher %{item}
+    clear_value: Apagar valor
+    click_to_reveal_filters: Clique para mostrar os filtros
+    confirm: Confirmar
+    create_new_item: Criar novo %{item}
+    dashboard: Painel
+    dashboards: Painéis
+    delete: apagar
+    delete_file: Apagar arquivo
+    delete_item: Apagar %{item}
+    detach_item: separar %{item}
+    details: detalhe
+    download: Download
+    download_file: Download do ficheiro
+    download_item: Download %{item}
+    edit: editar
+    edit_item: editar %{item}
+    empty_dashboard_message: Adicionar cartões a este painel
+    failed: Falhou
+    failed_to_find_attachment: Falha ao encontrar anexo
+    failed_to_load: Falhou ao carregar
+    field_translations:
+      file:
+        one: ficheiro
+        other: ficheiros
+        zero: ficheiros
+      people:
+        one: pessoa
+        other: pessoas
+        zero: ninguém
+    filter_by: Filtrar por
+    filters: Filtros
+    go_back: Voltar
+    grid_view: Visualização em grelha
+    hide_content: Esconder conteúdo
+    home: Início
+    key_value_field:
+      add_row: Adicionar linha
+      delete_row: Apagar linha
+      key: Chave
+      value: Valor
+    list_is_empty: Lista vazia
+    loading: A carregar
+    more: Mais
+    new: novo
+    next_page: Próxima página
+    no_cards_present: Nenhum cartão presente
+    no_item_found: Nenhum registro encontrado
+    no_options_available: Nenhuma opção disponível
+    no_related_item_found: Nenhum registro relacionado encontrado
+    not_authorized: Não está autorizado a executar essa ação.
+    number_of_items:
+      one: um %{item}
+      other: "%{count} %{item}"
+      zero: sem %{item}
+    oops_nothing_found: Oops! Nada encontrado...
+    order:
+      higher: Mover recurso para cima
+      lower: Mover recuros para baixo
+      reorder_record: Reordenar recurso
+      to_bottom: Mover recurso para o fundo
+      to_top: Mover recurso para o topo
+    per_page: Por página
+    prev_page: Página anterior
+    remove_selection: Remover seleção
+    reset_filters: Limpar filtros
+    resource_created: Recurso criado
+    resource_destroyed: Recurso destruído
+    resource_translations:
+      user:
+        one: utilizador
+        other: utilizadores
+        zero: utilizadores
+    resource_updated: Recurso atualizado
+    resources: Recursos
+    run: Executar
+    save: Guardar
+    search:
+      cancel_button: Cancelar
+      placeholder: Procurar
+    select_all: Selecionar tudo
+    select_all_matching: Selecionar todas as correspondências
+    select_item: Selecionar item
+    show_content: Mostrar conteúdo
+    sign_out: Terminar sessão
+    switch_to_view: Alterar para visão %{view_type}
+    table_view: Visualização em tabela
+    tools: Ferramentas
+    type_to_search: Escreva para pesquisar.
+    unauthorized: Não autorizado
+    undo: desfazer
+    view: Ver
+    view_item: ver %{item}
+    was_successfully_created: foi criado com sucesso
+    was_successfully_updated: foi atualizado com sucesso
+    x_items_more:
+      one: mais um item
+      other: "%{count} mais items"
+      zero: mais nenhum item
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> itens selecionados nesta página de um total de <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> itens selecionados de todas as páginas
+    you_missed_something_check_form: Pode ter-se esquecido algo. Por favor, verifique o formulário.

--- a/config/locales/avo.ro.yml
+++ b/config/locales/avo.ro.yml
@@ -1,0 +1,120 @@
+---
+ro:
+  avo:
+    action_ran_successfully: Acțiunea a rulat cu succes!
+    actions: Acțiuni
+    and_x_other_resources: plus alte %{count} recorduri
+    are_you_sure: Ești sigur?
+    are_you_sure_detach_item: Sigur vrei să detașezi asta %{item}.
+    are_you_sure_you_want_to_run_this_option: Ești sigur că vrei să rulezi aceasta acțiune?
+    attach: Atașează
+    attach_and_attach_another: Atașează și atașează inca unul
+    attach_item: Atașează %{item}
+    attachment_class_attached: "%{attachment_class} anexat."
+    attachment_class_detached: "%{attachment_class} separat."
+    attachment_destroyed: Atașamentul a fost distrus
+    cancel: Anulează
+    choose_a_country: Alege o țară
+    choose_an_option: Alege o opțiune
+    choose_item: Alege %{item}
+    clear_value: Șterge valoarea
+    click_to_reveal_filters: Faceți clic pentru a afișa filtrele
+    confirm: Confirm
+    create_new_item: Creează %{item}
+    dashboard: Panou de control
+    dashboards: Panouri de control
+    delete: șterge
+    delete_file: Șterge fișierul
+    delete_item: Șterge %{item}
+    detach_item: detașează %{item}
+    details: detalii
+    download: Descarcă
+    download_file: Descarcă fișier
+    download_item: Descarcă %{item}
+    edit: modifică
+    edit_item: modifică %{item}
+    empty_dashboard_message: Adaugă carduri în acest dashboard
+    failed: A eșuat
+    failed_to_find_attachment: Atașamentul nu a fost găsit
+    failed_to_load: Încărcarea a eșuat
+    field_translations:
+      file:
+        one: fișier
+        other: fișiere
+        zero: fișiere
+      people:
+        one: peep
+        other: peeps
+        zero: peeps
+    filter_by: Filtează după
+    filters: Filtre
+    go_back: Înapoi
+    grid_view: Vezi sub formă de grid
+    hide_content: Ascunde conținutul
+    home: Acasă
+    key_value_field:
+      add_row: Adaugă rând
+      delete_row: Șterge rând
+      key: Cheie
+      value: Valoare
+    list_is_empty: Lista este goală
+    loading: Se incarcă
+    more: Mai multe
+    new: nou
+    next_page: Pagina următoare
+    no_cards_present: Niciun card disponibil
+    no_item_found: Nici un articol găsit
+    no_options_available: Nicio opțiune disponibilă
+    no_related_item_found: Nici un articol asociat găsit
+    not_authorized: Nu sunteți autorizat să efectuați această acțiune.
+    number_of_items:
+      one: un %{item}
+      other: "%{count} %{item}"
+      zero: 0 %{item}
+    oops_nothing_found: Oups! Nu am găsit rezultate...
+    order:
+      higher: Mutați înregistrarea mai sus
+      lower: Mutați înregistrarea mai jos
+      reorder_record: Reordonați înregistrarea
+      to_bottom: Mutați înregistrarea jos de tot
+      to_top: Mutați înregistrarea sus de tot
+    per_page: Pe pagină
+    prev_page: Pagina anterioara
+    remove_selection: Șterge selecția
+    reset_filters: Resetați filtrele
+    resource_created: Resursă creata
+    resource_destroyed: Resursă ștearsă
+    resource_translations:
+      user:
+        one: utilizator
+        other: utilizatori
+        zero: utilizatori
+    resource_updated: Resursă actualizata
+    resources: Resurse
+    run: Rulează
+    save: Salvează
+    search:
+      cancel_button: Anulare
+      placeholder: Caută
+    select_all: Selectează totul
+    select_all_matching: Selectează toate care se potrivesc
+    select_item: Selectează record
+    show_content: Arată conținutul
+    sign_out: Delogare
+    switch_to_view: Comutați la vizualizarea %{view_type}
+    table_view: Vezi sub formă de tabel
+    tools: Instrumente
+    type_to_search: Caută aici...
+    unauthorized: Neautorizat
+    undo: Anulează
+    view: vezi
+    view_item: vezi %{item}
+    was_successfully_created: a fost creat
+    was_successfully_updated: a fost actualizat
+    x_items_more:
+      one: încă un articol
+      other: "%{count} mai multe articole"
+      zero: zero articole
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> selectate dintr-un total de <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> selectate din toate paginile
+    you_missed_something_check_form: S-ar putea să fi omis ceva. Vă rugăm să verificați formularul.

--- a/config/locales/avo.tr.yml
+++ b/config/locales/avo.tr.yml
@@ -1,0 +1,120 @@
+---
+tr:
+  avo:
+    action_ran_successfully: Eylem başarıyla gerçekleşti!
+    actions: Aksiyonlar
+    and_x_other_resources: ve %{count} diğer kaynak
+    are_you_sure: Emin misiniz?
+    are_you_sure_detach_item: "%{item} öğesini ayırmak istediğinizden emin misiniz?"
+    are_you_sure_you_want_to_run_this_option: Bu işlemi gerçekleştirmek istediğinize emin misiniz?
+    attach: İlişkilendir
+    attach_and_attach_another: İlişkilendir & Bir başka daha İlişkilendir
+    attach_item: "%{item} öğesini ilişkilendir"
+    attachment_class_attached: "%{attachment_class} ilişkilendirildi."
+    attachment_class_detached: "%{attachment_class} ilişkisi kesildi."
+    attachment_destroyed: Ek silindi
+    cancel: İptal et
+    choose_a_country: Bir ülke seç
+    choose_an_option: Bir seçenek seç
+    choose_item: "%{item} seçin"
+    clear_value: Değeri temizle
+    click_to_reveal_filters: Filtreleri ortaya çıkarmak için tıklayın
+    confirm: Onayla
+    create_new_item: Yeni bir %{item} oluşturun
+    dashboard: Yönetim Paneli
+    dashboards: Yönetim Panelleri
+    delete: sil
+    delete_file: Dosyayı sil
+    delete_item: "%{item} öğresini sil"
+    detach_item: "%{item} öğesinin ilişkisini kes"
+    details: detaylar
+    download: İndir
+    download_file: Dosya indir
+    download_item: "%{item} öğesini indir"
+    edit: düzenle
+    edit_item: "%{item} öğesini düzenle"
+    empty_dashboard_message: Kartları yönetim paneline ekle
+    failed: Başarısız
+    failed_to_find_attachment: Ek bulunamadı
+    failed_to_load: Yüklenemedi
+    field_translations:
+      file:
+        one: dosya
+        other: dosya
+        zero: dosya
+      people:
+        one: kişi
+        other: kişi
+        zero: kişi
+    filter_by: Tarafından filtre
+    filters: Filtreler
+    go_back: Geri dön
+    grid_view: Grid görünümü
+    hide_content: İçeriği gizle
+    home: Anasayfa
+    key_value_field:
+      add_row: Satır ekle
+      delete_row: Satır sil
+      key: Anahtar
+      value: Değer
+    list_is_empty: Boş liste
+    loading: Yükleniyor
+    more: Daha fazla
+    new: yeni
+    next_page: Sonraki sayfa
+    no_cards_present: Kart yok
+    no_item_found: Hiç bulunamadı
+    no_options_available: Seçenek yok
+    no_related_item_found: İlişkili bulunamadı
+    not_authorized: Bu eylemi gerçekleştirme yetkiniz yok.
+    number_of_items:
+      one: bir %{item}
+      other: "%{count} %{item}"
+      zero: sıfır %{item}
+    oops_nothing_found: Hata! Hiçbir şey bulunamadı
+    order:
+      higher: Kaydı yüksekten sırala
+      lower: Kaydı düşükten sırala
+      reorder_record: Kaydı yeniden sırala
+      to_bottom: Kaydı en alta taşı
+      to_top: Kaydı en üste taşı
+    per_page: Sayfa başına
+    prev_page: Önceki sayfa
+    remove_selection: Seçimi sil
+    reset_filters: Filtreleri sıfırla
+    resource_created: Kayıt oluşturuldu
+    resource_destroyed: Kayıt silindi
+    resource_translations:
+      user:
+        one: kullanıcı
+        other: kullanıcı
+        zero: kullanıcı
+    resource_updated: Kayıt güncellendi
+    resources: Kaynaklar
+    run: Başlat
+    save: Kaydet
+    search:
+      cancel_button: İptal et
+      placeholder: Ara
+    select_all: Tümünü seç
+    select_all_matching: Tüm eşleşenleri seç
+    select_item: Öğe seç
+    show_content: İçeriği göster
+    sign_out: Çıkış yap
+    switch_to_view: "%{view_type} görünümüne kay"
+    table_view: Tablo görünümü
+    tools: Araçlar
+    type_to_search: Aramak için yazın.
+    unauthorized: Yetkisiz
+    undo: geri al
+    view: Görünüm
+    view_item: "%{item} öğresini görüntüle"
+    was_successfully_created: başarıyla oluşturuldu
+    was_successfully_updated: başarıyla güncellendi
+    x_items_more:
+      one: bir öğe daha
+      other: "%{count} öğe daha"
+      zero: daha fazla öğe yok
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> bu sayfada seçilen toplam kayıtlar <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> tüm sayfalardan seçilen kayıtlar
+    you_missed_something_check_form: Bir şeyleri kaçırmış olabilirsiniz. Lütfen formu kontrol edin.

--- a/config/locales/pagy/nn.yml
+++ b/config/locales/pagy/nn.yml
@@ -1,0 +1,15 @@
+nn:
+  pagy:
+    item_name:
+      one: "resultat"
+      other: "resultat"
+    nav:
+      prev: "&lsaquo;&nbsp;Førre"
+      next: "Neste&nbsp;&rsaquo;"
+      gap: "&hellip;"
+    info:
+      no_items: "Ingen %{item_name} funne"
+      single_page: "Viser <b>%{count}</b> %{item_name}"
+      multiple_pages: "Viser %{item_name} <b>%{from}-%{to}</b> av totalt <b>%{count}</b>"
+    combo_nav_js: "<label>Side %{page_input} av %{pages}</label>"
+    items_selector_js: "<label>Vis %{items_input} %{item_name} per side</label>"

--- a/config/locales/pagy/ro.yml
+++ b/config/locales/pagy/ro.yml
@@ -1,0 +1,17 @@
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/locales/utils/p11n.rb)
+
+ro:
+  pagy:
+    item_name:
+      one: "un record"
+      other: "recorduri"
+    nav:
+      prev: "&lsaquo;&nbsp;Înapoi"
+      next: "Înainte&nbsp;&rsaquo;"
+      gap: "&hellip;"
+    info:
+      no_items: "Nici %{item_name} găsit"
+      single_page: "<b>%{count}</b> %{item_name}"
+      multiple_pages: "<b>%{from}-%{to}</b> din totalul de <b>%{count}</b>"
+    combo_nav_js: "<label>Pagina %{page_input} din %{pages}</label>"
+    items_selector_js: "<label>Show %{items_input} %{item_name} per page</label>"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Avo::Engine, at: Avo.configuration.root_path
+
   get "/robots.:format", to: "pages#robots"
 
   scope via: :all do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  mount Avo::Engine, at: Avo.configuration.root_path
-
   get "/robots.:format", to: "pages#robots"
 
   scope via: :all do
@@ -48,5 +46,9 @@ Rails.application.routes.draw do
     post "/confirm-password",
          to: "app#confirm_password",
          as: "app_confirm_password"
+  end
+
+  authenticate :user, ->(user) { user.admin? } do
+    mount Avo::Engine => "/avo"
   end
 end

--- a/db/migrate/20230309180122_add_admin_to_users.rb
+++ b/db/migrate/20230309180122_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_25_131201) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_09_180122) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,6 +106,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_131201) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "team_id"
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["team_id"], name: "index_users_on_team_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  admin                  :boolean          default(FALSE), not null
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :string
 #  email                  :string           default(""), not null


### PR DESCRIPTION
This uses [Avo](https://avohq.io/) which is a modern admin panel for Rails apps. It has a free community licence which probably has enough features for our needs. More advanced features are available with a paid licence.

While it doesn't follow the design language or theme of the rest of the app, the fact that it comes pre-built and does all the CRUDy bits is pretty useful. It requires less development time to stand up and lets us perform back-office tasks without having to dip into a Rails console.

If this is good enough, we can add more doohickeys to it in a follow-up PR.

### After

Navigate to `/avo` as an admin user, and click on `Users` in the sidebar:

![image](https://user-images.githubusercontent.com/1650875/224365186-92ef4b9a-423b-4e23-9166-ac336c2dc423.png)
