### PR TITLE
Add captions

### DIFF
--- a/app/controllers/post_images_controller.rb
+++ b/app/controllers/post_images_controller.rb
@@ -48,7 +48,7 @@ class PostImagesController < ApplicationController
   end
 
   def update_params
-    params.require(:attachment).permit(:title, :alt_text)
+    params.require(:attachment).permit(:title, :alt_text, :caption)
   end
 
   def set_project

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,6 +40,10 @@ module ApplicationHelper
     (image.custom_metadata["alt_text"].presence || image_title(image))
   end
 
+  def image_caption(image)
+    image.custom_metadata["caption"]
+  end
+
   def humanize_image_title(image)
     extension = File.extname(image.filename.to_s)
     filename = image.filename.to_s.chomp extension

--- a/app/views/post_images/index.html.erb
+++ b/app/views/post_images/index.html.erb
@@ -52,6 +52,7 @@
                       alt: image_alt_text_fallback(image),
                       class: 'govuk-!-margin-bottom-2',
                       style: 'max-width: 100%; border: 1px solid #000' %>
+                    <%= GovukMarkdown.render(image_caption(image)).html_safe if image_caption(image).present? %>
 
                     <div class="app-upload__attachment-buttons govuk-button-group">
                       <%= render "buttons", image: %>
@@ -71,12 +72,12 @@
                       value: image_alt_text(image) %>
 
                     <%= f.govuk_text_area :caption, rows: 5,
-                      disabled: true, placeholder: "Not implemented",
                       label: { text: "Caption" },
                       hint: {
                         text: "Optional. You can use markdown",
                         class: 'govuk-hint govuk-!-font-size-16'
-                      } %>
+                      },
+                      value: image_caption(image) %>
 
                     <%= f.govuk_submit "Save", class: 'govuk-!-margin-top-4' %>
                   <% end %>

--- a/app/views/shared/_screenshots.html.erb
+++ b/app/views/shared/_screenshots.html.erb
@@ -21,6 +21,11 @@
       <%= link_to image do %>
         <%= image_tag image, alt: image_alt_text_fallback(image) %>
       <% end %>
+      <% if image_caption(image).present? %>
+        <figcaption>
+          <%= GovukMarkdown.render(image_caption(image)).html_safe %>
+        </figcaption>
+      <% end %>
     </figure>
   <% end %>
 </section>

--- a/spec/system/screenshots_spec.rb
+++ b/spec/system/screenshots_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe "Screenshots" do
 
     when_i_edit_the_first_image_alt_text
     then_the_alt_text_is_updated
+
+    when_i_edit_the_first_image_caption
+    then_the_caption_is_updated
   end
 
   private
@@ -101,5 +104,16 @@ RSpec.describe "Screenshots" do
 
   def then_the_alt_text_is_updated
     expect(@post.images.first.custom_metadata["alt_text"]).to eq "New alt text"
+  end
+
+  def when_i_edit_the_first_image_caption
+    first("textarea[name*='caption']").set "New **caption**"
+    first("button", text: "Save").click
+  end
+
+  def then_the_caption_is_updated
+    expect(
+      @post.images.first.custom_metadata["caption"]
+    ).to eq "New **caption**"
   end
 end


### PR DESCRIPTION
Images now have a Markdown-enabled caption field which shows up under images on the screenshot editing page and on the post page.