### PR TITLE
Default to today when publishing

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -47,6 +47,7 @@ class Post < ApplicationRecord
             }
   validates :published_at, presence: true, if: -> { published == true }
   before_validation :generate_slug_from_title, on: %i[create update]
+  before_validation :set_published_at, on: %i[create update]
 
   def ordered_images
     images.sort_by do |image|
@@ -102,5 +103,9 @@ class Post < ApplicationRecord
   def generate_slug_from_title
     self.slug = title.parameterize.slice(0, MAX_SLUG_LENGTH) if slug.blank? &&
       title.present?
+  end
+
+  def set_published_at
+    self.published_at = Time.zone.today if published? && published_at.blank?
   end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -23,8 +23,15 @@
       multiple: false,
       label: { text: "Published" } %>
   <% end %>
-  <%= f.govuk_date_field :published_at,
-    legend: { text: 'Published date' } %>
+
+  <%= govuk_details(summary_text: 'Change published date') do %>
+    <%= f.govuk_date_field :published_at,
+      legend: {
+        text: 'Published date (optional)',
+        class: 'govuk-fieldset__legend--s'
+      },
+      hint: { text: 'Defaults to today when published' } %>
+  <% end %>
 
   <%= f.govuk_submit "Save" %>
 <% end %>

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Posts" do
 
     when_i_publish_my_post
     then_i_see_the_edit_post_page
+    and_i_see_a_publish_date_that_is_today
     and_i_see_a_view_post_link
   end
 
@@ -50,15 +51,29 @@ RSpec.describe "Posts" do
   end
 
   def when_i_publish_my_post
-    fill_in "post[published_at(3i)]", with: "1"
-    fill_in "post[published_at(2i)]", with: "1"
-    fill_in "post[published_at(1i)]", with: "2001"
     find('label[for*="post-published"]').click
     click_button "Save"
   end
 
   def then_i_see_the_edit_post_page
     expect(page).to have_content "Editing post"
+  end
+
+  def and_i_see_a_publish_date_that_is_today
+    expect(page).to have_field(
+      "post[published_at(1i)]",
+      with: Time.zone.today.year
+    )
+
+    expect(page).to have_field(
+      "post[published_at(2i)]",
+      with: Time.zone.today.month
+    )
+
+    expect(page).to have_field(
+      "post[published_at(3i)]",
+      with: Time.zone.today.day
+    )
   end
 
   def and_i_see_a_view_post_link


### PR DESCRIPTION
- Don't force users to enter a publish date
- Default to today
- Hide the publish date fields behind a details component

<img width="447" alt="Screenshot 2023-03-13 at 11 32 09" src="https://user-images.githubusercontent.com/319055/224690601-a59ba0f6-35c8-4b13-a642-274e36850e33.png">
<img width="410" alt="Screenshot 2023-03-13 at 11 32 05" src="https://user-images.githubusercontent.com/319055/224690607-52cc51a7-aa56-47ce-9adc-62124643a2c9.png">
