### PR TITLE
Simplify "New post" page

### DIFF
--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -5,11 +5,26 @@
   }) %>
 <% end %>
 
-<% title = "New post" %>
-<%= content_for :page_title, title %>
-<h1 class="govuk-heading-xl"><%= title %></h1>
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <%= form_with(model: [@project, @post]) do |f| %>
+      <%= f.govuk_error_summary %>
+    <% end %>
 
-<%= render "form", project: @project, post: @post %>
+    <% title = "New post" %>
+    <%= content_for :page_title, title %>
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <%= form_with(model: [@project, @post]) do |f| %>
+      <%= f.govuk_text_field :title,
+        label: { text: 'Title', size: 'm' },
+        hint: { text: 'Good titles describe the post, do not use ‘User
+                research’ or ‘MVP’' } %>
+
+      <%= f.govuk_submit "Save" %>
+    <% end %>
+  <% end %>
+<% end %>
 
 <div>
   <%= govuk_link_to "Back to posts", project_posts_path(@project) %>

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe "Posts" do
     when_i_submit_my_post_details
     then_i_see_the_edit_post_page
 
+    when_i_update_my_post
+    then_i_see_the_edit_post_page
+
     when_i_publish_my_post
     then_i_see_the_edit_post_page
     and_i_see_a_publish_date_that_is_today
@@ -43,8 +46,12 @@ RSpec.describe "Posts" do
   end
 
   def when_i_submit_my_post_details
-    @slug = Faker::Internet.slug.gsub("_", "-")
     fill_in "post[title]", with: Faker::Company.bs.capitalize
+    click_button "Save"
+  end
+
+  def when_i_update_my_post
+    @slug = Faker::Internet.slug.gsub("_", "-")
     fill_in "post[slug]", with: @slug
     fill_in "post[body]", with: Faker::Markdown.sandwich
     click_button "Save"


### PR DESCRIPTION
Reduce this page to just a form asking for the Title. This way, users are less likely to be confused why the form is missing components such as the screenshots section.

Fixes #193.

### After

![image](https://user-images.githubusercontent.com/1650875/224775214-013da335-d5e6-4334-8ff2-2bfa162d3c15.png)

![image](https://user-images.githubusercontent.com/1650875/224775558-48943629-bc86-417a-9cf5-530ff05abc58.png)

