### PR TITLE
Remove replace_on_assign_to_many = false setting

### DIFF
--- a/app/controllers/post_images_controller.rb
+++ b/app/controllers/post_images_controller.rb
@@ -44,7 +44,7 @@ class PostImagesController < ApplicationController
   private
 
   def create_params
-    params.require(:post).permit(images: [])
+    params.require(:post).permit(append_images: [])
   end
 
   def update_params

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -75,6 +75,10 @@ class Post < ApplicationRecord
     ordered_images.index(image) == ordered_images.size - 1
   end
 
+  def append_images=(imgs)
+    images.attach(imgs)
+  end
+
   private
 
   def ordered_image_move!(image, where)

--- a/app/views/post_images/index.html.erb
+++ b/app/views/post_images/index.html.erb
@@ -95,10 +95,10 @@
         <%= form_with(model: @post,
                       url: project_post_images_path(@project, @post),
                       method: :post) do |f| %>
-          <%= f.label :images, "Add more images",
+          <%= f.label :append_images, "Add more images",
             class: 'govuk-label govuk-label--s govuk-!-margin-top-2
                     govuk-!-margin-bottom-2' %>
-          <%= f.file_field :images,
+          <%= f.file_field :append_images,
             multiple: true, accept: 'image/png,image/jpeg,image/gif' %>
 
           <%= f.govuk_submit "Add images", class: 'govuk-!-margin-top-4' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,8 +39,6 @@ module DesignHistory
 
     config.exceptions_app = routes
 
-    config.active_storage.replace_on_assign_to_many = false
-
     config.generators { |g| g.test_framework :rspec }
   end
 end

--- a/spec/system/screenshots_spec.rb
+++ b/spec/system/screenshots_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Screenshots" do
   end
 
   def when_i_upload_an_image
-    attach_file "post[images][]",
+    attach_file "post[append_images][]",
                 Rails.root.join("spec/fixtures/files/screenshot.png")
     click_button "Add images"
   end
@@ -65,7 +65,7 @@ RSpec.describe "Screenshots" do
   end
 
   def when_i_upload_another_image
-    attach_file "post[images][]",
+    attach_file "post[append_images][]",
                 Rails.root.join("spec/fixtures/files/screenshot2.png")
     click_button "Add images"
   end


### PR DESCRIPTION
This is deprecated in Rails 7.1 and was coming up as a warning during our test run.

We can instead rely on the `.attach` method.

Based on https://stackoverflow.com/a/71990877