### PR TITLE
Handle error when users incorrectly enter published_at

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -24,7 +24,8 @@
       label: { text: "Published" } %>
   <% end %>
 
-  <%= govuk_details(summary_text: 'Change published date') do %>
+  <%= govuk_details(summary_text: 'Change published date',
+                    open: post.errors[:published_at].any?) do %>
     <%= f.govuk_date_field :published_at,
       legend: {
         text: 'Published date (optional)',

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -54,6 +54,7 @@ en:
               blank: Enter a body
             published_at:
               blank: Enter a published at date
+              invalid: Enter a valid date, like 15 3 2023
         team:
           attributes:
             name:

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe "Posts" do
     then_i_see_the_edit_post_page
     and_i_see_a_publish_date_that_is_today
     and_i_see_a_view_post_link
+
+    when_i_set_the_publish_date_month_to_an_invalid_value
+    then_i_see_an_error
   end
 
   private
@@ -88,5 +91,14 @@ RSpec.describe "Posts" do
       "a[href*='#{@project.subdomain}'][href*='#{@slug}']",
       text: "View post"
     )
+  end
+
+  def when_i_set_the_publish_date_month_to_an_invalid_value
+    fill_in "post[published_at(2i)]", with: "13"
+    click_button "Save"
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content "Enter a valid date, like 15 3 2023"
   end
 end


### PR DESCRIPTION
When users input invalid parameters to the published_at date fields, Rails picks these up as `published_at(1i)`, `published_at(2i)` and `published_at(3i)`. These then get passed directly to `.update`.

If any of these parameters are out of range, this triggers a multiparameter assignment error, which is a 500.

It isn't possible to guard for these in the model, because the field is of type date, and we can't create a valid date object from invalid parameters.

Because of this, we have to validate in the controller, which is a bit messy.

## After

![image](https://user-images.githubusercontent.com/1650875/225405584-d0db7798-8a57-4035-ae81-3a2e8644f3d2.png)
