### PR TITLE
Set all images to public by default

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,3 +13,4 @@ digitalocean:
   secret_access_key: <%= Rails.application.credentials.dig(:digitalocean, :secret) %>
   bucket: design-history
   region: unused
+  public: true

--- a/lib/tasks/update_spaces_access_control.rake
+++ b/lib/tasks/update_spaces_access_control.rake
@@ -1,0 +1,32 @@
+require "aws-sdk-s3"
+
+namespace :spaces do
+  desc "Update access control settings for all objects in the DigitalOcean Spaces bucket"
+  task update_access_control: :environment do
+    # Replace with your own credentials and bucket information
+    access_key_id =
+      Rails.application.credentials.dig(:digitalocean, :access_key_id)
+    secret_access_key =
+      Rails.application.credentials.dig(:digitalocean, :secret_access_key)
+    region = "ams3"
+    bucket_name = "design-history"
+
+    # Initialize the S3 client
+    s3_client =
+      Aws::S3::Client.new(
+        access_key_id:,
+        secret_access_key:,
+        region:,
+        endpoint: "https://#{region}.digitaloceanspaces.com"
+      )
+
+    # Update the access control settings for each object in the bucket
+    s3_resource = Aws::S3::Resource.new(client: s3_client)
+    bucket = s3_resource.bucket(bucket_name)
+
+    bucket.objects.each do |object|
+      puts "Updating access control for #{object.key}"
+      object.acl.put({ acl: "public-read" })
+    end
+  end
+end


### PR DESCRIPTION
Currently, images are private on DigitalOcean Spaces. This means that embedding them in posts requires generating a one-time URL with access controls.

Instead, we can make the images public by default, and migrate all existing images to public using a rake task.

Note that public isn't the same as enumerable/guessable, as File listing is still set to Restricted in the bucket settings. An example of a public image is this:

https://design-history.ams3.digitaloceanspaces.com/8x3eyop5d3xd0ea5uax11lwlzkrx

So anyone can see it as long as they have that URL. The URL does not have any auth cookie/credentials attached, and it never expires. But guessing that UUID at the end isn't possible, except if you view a post. This seems like a good trade-off for now, but we might consider adding "fully private image hosting" later if deemed necessary.