### PR TITLE
Add initial support for comments

### DIFF
--- a/app/avo/resources/comment_resource.rb
+++ b/app/avo/resources/comment_resource.rb
@@ -1,0 +1,16 @@
+class CommentResource < Avo::BaseResource
+  self.title = :id
+  self.includes = []
+  # self.search_query = -> do
+  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+  # end
+
+  field :id, as: :id
+  # Fields generated from the model
+  field :body, as: :textarea
+  field :email, as: :text
+  field :name, as: :text
+  field :commentable_id, as: :number
+  field :commentable_type, as: :text
+  # add fields here
+end

--- a/app/controllers/app_controller.rb
+++ b/app/controllers/app_controller.rb
@@ -11,6 +11,7 @@ class AppController < ApplicationController
   def show
     @post =
       @project.posts.friendly.where(published: true).find(params[:post_id])
+    @comment = Comment.new
   end
 
   def confirm_password

--- a/app/controllers/avo/comments_controller.rb
+++ b/app/controllers/avo/comments_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::CommentsController < Avo::ResourcesController
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,31 @@
+class CommentsController < ApplicationController
+  before_action :set_post
+
+  def new
+    @comment = Comment.new
+  end
+
+  def create
+    @comment = @post.comments.new comment_params
+
+    if @comment.save
+      redirect_to app_post_path(@post),
+                  notice: "Your comment was successfully posted"
+    else
+      @post.reload # Clear out the comment we just added
+      render template: "app/show", status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body, :name, :email)
+  end
+
+  def set_post
+    @project = Project.find_by!(subdomain: request.subdomain)
+    @post =
+      @project.posts.friendly.where(published: true).find(params[:post_id])
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -58,7 +58,8 @@ class ProjectsController < ApplicationController
       :subdomain,
       :description,
       :theme,
-      :related_links
+      :related_links,
+      :comments_enabled
     )
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -18,4 +18,15 @@
 class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
   has_many :comments, as: :commentable, dependent: :destroy
+
+  validates :body, presence: true, length: { maximum: 1000 }
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :email,
+            presence: true,
+            format: {
+              with: URI::MailTo::EMAIL_REGEXP
+            },
+            length: {
+              maximum: 255
+            }
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id               :bigint           not null, primary key
+#  body             :text             not null
+#  commentable_type :string           not null
+#  email            :string           not null
+#  name             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  commentable_id   :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_commentable  (commentable_type,commentable_id)
+#
+class Comment < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+  has_many :comments, as: :commentable, dependent: :destroy
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -29,6 +29,7 @@ class Post < ApplicationRecord
   belongs_to :project
 
   has_many_attached :images
+  has_many :comments, as: :commentable, dependent: :destroy
 
   extend FriendlyId
   friendly_id :title, use: :slugged

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,17 +2,18 @@
 #
 # Table name: projects
 #
-#  id            :bigint           not null, primary key
-#  description   :string
-#  owner_type    :string           not null
-#  password      :string
-#  related_links :text             default("")
-#  subdomain     :string
-#  theme         :string           default("dh"), not null
-#  title         :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  owner_id      :bigint           not null
+#  id               :bigint           not null, primary key
+#  comments_enabled :boolean          default(FALSE)
+#  description      :string
+#  owner_type       :string           not null
+#  password         :string
+#  related_links    :text             default("")
+#  subdomain        :string
+#  theme            :string           default("dh"), not null
+#  title            :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  owner_id         :bigint           not null
 #
 # Indexes
 #

--- a/app/views/app/show.html.erb
+++ b/app/views/app/show.html.erb
@@ -31,7 +31,9 @@
     </div>
 
     <%= render "shared/screenshots", post: @post if @post.ordered_images.any? %>
-    <%= render "shared/comments", post: @post, comment: @comment if @post.published? %>
+    <%= render "shared/comments",
+      post: @post,
+      comment: @comment if @post.published? && @project.comments_enabled? %>
   <% end %>
 
   <%= govuk_one_third do %>

--- a/app/views/app/show.html.erb
+++ b/app/views/app/show.html.erb
@@ -31,6 +31,7 @@
     </div>
 
     <%= render "shared/screenshots", post: @post if @post.ordered_images.any? %>
+    <%= render "shared/comments", post: @post, comment: @comment if @post.published? %>
   <% end %>
 
   <%= govuk_one_third do %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -45,6 +45,34 @@
         :name,
         legend: { text: 'Pick a design history style' } %>
 
+      <% legend = -> {
+        tag.legend class: 'govuk-fieldset__legend govuk-fieldset__legend--m' do
+          [tag.span("Comments"), govuk_tag(text: "Beta", colour: "blue")]
+            .join(" ").html_safe
+        end
+      } %>
+
+      <%= f.govuk_check_boxes_fieldset :comments_enabled,
+        multiple: false,
+        legend: legend do %>
+        <p>
+          Comments are in beta. We're still building out their functionality.
+        </p>
+
+        <p>Currently, comments are:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>public</li>
+          <li>not moderated</li>
+          <li>not threaded</li>
+          <li>not editable</li>
+          <li>not deletable</li>
+        </ul>
+
+        <%= f.govuk_check_box :comments_enabled, 1, 0, multiple: false,
+          link_errors: true, label: { text: 'Enable comments' } %>
+      <% end %>
+
       <%= f.govuk_submit editing ? "Save changes" : "Create design history" %>
     <% end %>
   <% end %>

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -1,42 +1,45 @@
-<section>
-  <% if post.comments.any? %>
-    <h3><%= pluralize(post.comments.size, 'comment') %></h3>
-    <ul class="govuk-list">
-      <% post.comments.each do |comment| %>
-        <li id="comment-<%= comment.id %>">
-          <p>
-            <span class="govuk-visually-hidden">Comment by</span>
-            <span class="govuk-!-font-weight-bold"><%= comment.name %></span>
-            <span class="govuk-visually-hidden">posted on </span>
-            <time class="app-metadata" datetime="<% comment.created_at.iso8601 %>">
-              <%= comment.created_at.strftime("%-d %B %Y") %>
-            </time>
-          </p>
+<%= turbo_frame_tag "comments" do %>
+  <section>
+    <% if post.comments.any? %>
+      <h3><%= pluralize(post.comments.size, 'comment') %></h3>
+      <ul class="govuk-list">
+        <% post.comments.each do |comment| %>
+          <li id="comment-<%= comment.id %>">
+            <p>
+              <span class="govuk-visually-hidden">Comment by</span>
+              <span class="govuk-!-font-weight-bold"><%= comment.name %></span>
+              <span class="govuk-visually-hidden">posted on </span>
+              <time class="app-metadata" datetime="<% comment.created_at.iso8601 %>">
+                <%= comment.created_at.strftime("%-d %B %Y") %>
+              </time>
+            </p>
 
-          <p><%= comment.body %></p>
+            <p><%= comment.body %></p>
 
-          <p class="govuk-!-font-size-16">
-            <a href="#comment-<%= comment.id %>">Link to this comment
-              <span class="govuk-visually-hidden"> by <%= comment.name %></span>
-            </a>
-          </p>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
+            <p class="govuk-!-font-size-16">
+              <a href="#comment-<%= comment.id %>" target="_top">
+                Link to this comment
+                <span class="govuk-visually-hidden"> by <%= comment.name %></span>
+              </a>
+            </p>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
 
-  <h3>Leave a comment</h3>
+    <h3>Leave a comment</h3>
 
-  <%= form_with(model: comment) do |f| %>
-    <%= f.govuk_error_summary %>
-    <%= f.govuk_text_area :body, rows: 10,
-      label: { text: 'Enter your comment' } %>
-    <%= f.govuk_text_field :name,
-      label: { text: 'Name' } %>
-    <%= f.govuk_text_field :email,
-      label: { text: 'Email' },
-      hint: { text: 'We only ask for your email so we know you\'re a real person' } %>
+    <%= form_with(model: comment) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_area :body, rows: 10,
+        label: { text: 'Enter your comment' } %>
+      <%= f.govuk_text_field :name,
+        label: { text: 'Name' } %>
+      <%= f.govuk_text_field :email,
+        label: { text: 'Email' },
+        hint: { text: 'We only ask for your email so we know you\'re a real person' } %>
 
-    <%= f.govuk_submit "Submit comment" %>
-  <% end %>
-</section>
+      <%= f.govuk_submit "Submit comment" %>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -1,31 +1,42 @@
 <section>
-  <h3><%= post.comments.any? ?
-    pluralize(post.comments.size, 'comment') :
-    "Leave a comment" %>
-  </h3>
-
   <% if post.comments.any? %>
+    <h3><%= pluralize(post.comments.size, 'comment') %></h3>
     <ul class="govuk-list">
       <% post.comments.each do |comment| %>
-        <li>
+        <li id="comment-<%= comment.id %>">
+          <p>
+            <span class="govuk-visually-hidden">Comment by</span>
+            <span class="govuk-!-font-weight-bold"><%= comment.name %></span>
+            <span class="govuk-visually-hidden">posted on </span>
+            <time class="app-metadata" datetime="<% comment.created_at.iso8601 %>">
+              <%= comment.created_at.strftime("%-d %B %Y") %>
+            </time>
+          </p>
+
           <p><%= comment.body %></p>
-          <p><%= comment.name %></p>
-          <p><%= comment.email %></p>
+
+          <p class="govuk-!-font-size-16">
+            <a href="#comment-<%= comment.id %>">Link to this comment
+              <span class="govuk-visually-hidden"> by <%= comment.name %></span>
+            </a>
+          </p>
         </li>
       <% end %>
     </ul>
   <% end %>
 
-  <%= form_with(model: post.comments.new) do |f| %>
+  <h3>Leave a comment</h3>
+
+  <%= form_with(model: comment) do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_text_field :body,
-      label: { text: 'Enter your comment', size: 'm' } %>
+    <%= f.govuk_text_area :body, rows: 10,
+      label: { text: 'Enter your comment' } %>
     <%= f.govuk_text_field :name,
-      label: { text: 'Name', size: 'm' } %>
-    <%= f.govuk_text_area :email, rows: 20,
-      label: { text: 'Email', size: 'm' },
+      label: { text: 'Name' } %>
+    <%= f.govuk_text_field :email,
+      label: { text: 'Email' },
       hint: { text: 'We only ask for your email so we know you\'re a real person' } %>
 
     <%= f.govuk_submit "Submit comment" %>
   <% end %>
-</section
+</section>

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -1,0 +1,31 @@
+<section>
+  <h3><%= post.comments.any? ?
+    pluralize(post.comments.size, 'comment') :
+    "Leave a comment" %>
+  </h3>
+
+  <% if post.comments.any? %>
+    <ul class="govuk-list">
+      <% post.comments.each do |comment| %>
+        <li>
+          <p><%= comment.body %></p>
+          <p><%= comment.name %></p>
+          <p><%= comment.email %></p>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <%= form_with(model: post.comments.new) do |f| %>
+    <%= f.govuk_error_summary %>
+    <%= f.govuk_text_field :body,
+      label: { text: 'Enter your comment', size: 'm' } %>
+    <%= f.govuk_text_field :name,
+      label: { text: 'Name', size: 'm' } %>
+    <%= f.govuk_text_area :email, rows: 20,
+      label: { text: 'Email', size: 'm' },
+      hint: { text: 'We only ask for your email so we know you\'re a real person' } %>
+
+    <%= f.govuk_submit "Submit comment" %>
+  <% end %>
+</section

--- a/config/locales/validations.en.yml
+++ b/config/locales/validations.en.yml
@@ -60,6 +60,18 @@ en:
             name:
               blank: Enter a name
               too_long: Enter a name that is less than 50 characters long
+        comment:
+          attributes:
+            body:
+              blank: Enter a comment
+              too_long: Enter a comment that is less than 1000 characters long
+            name:
+              blank: Enter a name
+              too_long: Enter a name that is less than 255 characters long
+            email:
+              blank: Enter an email address
+              invalid: Enter an email address in the correct format, like
+                name@example.com
   activemodel:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,10 @@ Rails.application.routes.draw do
     get "/", to: "app#index", as: "app_posts"
     get "/:post_id", to: "app#show", as: "app_post"
 
+    scope "/:post_id" do
+      resources :comments, only: [:create]
+    end
+
     post "/confirm-password",
          to: "app#confirm_password",
          as: "app_confirm_password"

--- a/db/migrate/20230427084754_create_comments.rb
+++ b/db/migrate/20230427084754_create_comments.rb
@@ -1,0 +1,12 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.text :body, null: false
+      t.string :email, null: false
+      t.string :name, null: false
+      t.references :commentable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230427123444_add_comments_enabled_to_projects.rb
+++ b/db/migrate/20230427123444_add_comments_enabled_to_projects.rb
@@ -1,0 +1,5 @@
+class AddCommentsEnabledToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :comments_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_09_180122) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_27_084754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_09_180122) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body", null: false
+    t.string "email", null: false
+    t.string "name", null: false
+    t.string "commentable_type", null: false
+    t.bigint "commentable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_27_084754) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_27_123444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,6 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_084754) do
     t.bigint "owner_id", null: false
     t.string "theme", default: "dh", null: false
     t.text "related_links", default: ""
+    t.boolean "comments_enabled", default: false
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
   end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id               :bigint           not null, primary key
+#  body             :text             not null
+#  commentable_type :string           not null
+#  email            :string           not null
+#  name             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  commentable_id   :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_commentable  (commentable_type,commentable_id)
+#
+FactoryBot.define do
+  factory :comment do
+    body { "MyText" }
+    email { "MyString" }
+    name { "MyString" }
+    commentable_id { 1 }
+    commentable_type { "MyString" }
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,17 +2,18 @@
 #
 # Table name: projects
 #
-#  id            :bigint           not null, primary key
-#  description   :string
-#  owner_type    :string           not null
-#  password      :string
-#  related_links :text             default("")
-#  subdomain     :string
-#  theme         :string           default("dh"), not null
-#  title         :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  owner_id      :bigint           not null
+#  id               :bigint           not null, primary key
+#  comments_enabled :boolean          default(FALSE)
+#  description      :string
+#  owner_type       :string           not null
+#  password         :string
+#  related_links    :text             default("")
+#  subdomain        :string
+#  theme            :string           default("dh"), not null
+#  title            :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  owner_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Comments" do
+  it "can be be submitted on public posts" do
+    when_i_visit_my_design_history_post
+    then_i_see_the_comments_section
+
+    when_i_post_a_comment
+    then_i_see_my_comment
+  end
+
+  private
+
+  def when_i_visit_my_design_history_post
+    @owner = create(:user)
+    @project = create(:project, owner: @owner, subdomain: "this")
+    @first_post = create(:post, project: @project, body: "It's working")
+    port = page.driver.browser.options.port
+    visit "http://this.app.local:#{port}"
+    click_link @first_post.title
+  end
+
+  def then_i_see_the_comments_section
+    expect(page).to have_content "Leave a comment"
+  end
+
+  def when_i_post_a_comment
+    fill_in "Name", with: "John Doe"
+    fill_in "Email", with: "john.doe@example.com"
+    fill_in "Enter your comment", with: "This is a comment"
+    click_button "Submit comment"
+  end
+
+  def then_i_see_my_comment
+    expect(page).to have_content "1 comment"
+    expect(page).to have_content "This is a comment"
+  end
+end

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe "Comments" do
     when_i_visit_my_design_history_post
     then_i_see_the_comments_section
 
+    when_i_post_an_invalid_comment
+    then_i_see_an_error_message
+
     when_i_post_a_comment
     then_i_see_my_comment
   end
@@ -34,5 +37,13 @@ RSpec.describe "Comments" do
   def then_i_see_my_comment
     expect(page).to have_content "1 comment"
     expect(page).to have_content "This is a comment"
+  end
+
+  def when_i_post_an_invalid_comment
+    click_button "Submit comment"
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content "Enter an email"
   end
 end

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -3,6 +3,14 @@ require "rails_helper"
 RSpec.describe "Comments" do
   it "can be be submitted on public posts" do
     when_i_visit_my_design_history_post
+    then_i_dont_see_the_comments_section
+
+    when_i_sign_in
+    and_i_go_to_my_project_settings
+    then_i_see_the_comments_setting
+
+    when_i_enable_comments
+    and_i_visit_my_design_history_post
     then_i_see_the_comments_section
 
     when_i_post_an_invalid_comment
@@ -23,8 +31,36 @@ RSpec.describe "Comments" do
     click_link @first_post.title
   end
 
+  def and_i_visit_my_design_history_post
+    port = page.driver.browser.options.port
+    visit "http://this.app.local:#{port}"
+    click_link @first_post.title
+  end
+
+  def when_i_sign_in
+    sign_in @owner
+    visit project_path(@project)
+  end
+
+  def when_i_enable_comments
+    check "Enable comments", allow_label_click: true
+    click_button "Save changes"
+  end
+
+  def and_i_go_to_my_project_settings
+    click_link "Change details"
+  end
+
+  def then_i_see_the_comments_setting
+    expect(page).to have_content "Enable comments"
+  end
+
   def then_i_see_the_comments_section
     expect(page).to have_content "Leave a comment"
+  end
+
+  def then_i_dont_see_the_comments_section
+    expect(page).not_to have_content "Leave a comment"
   end
 
   def when_i_post_a_comment


### PR DESCRIPTION
We've received feedback on one of our design histories that our colleagues would like to be able to comment on the individual posts.

This adds a commenting feature to public posts. The design is very similar to the one on the GOV.UK blog,

Notably absent:

- Support for threaded replies
- "Email me if someone replies to my comment"
- No animation / folding of input fields when initially loaded

There is a back-office interface to see and manage comments at `/avo/resources/comments`.

~~More important to consider is that there's no way to selectively turn off comments on certain posts, or to moderate them as an end user. Let's discuss here if we think we need the former at this stage as it's not much effort to make this feature opt-in by adding a flag on each post (or on a design history, wherever it makes sense).~~ Discussed in Slack, this feature is now togglable from the design history settings.

Also missing is spam filtering, that's definitely coming in a follow-up PR.

Comments have the following restrictions:

- Valid email
- Name no longer than 255 characters
- Body no longer than 1000 characters

Other bugs that could be resolved in this PR:

- ~~Entering invalid data produces an error summary, but the scroll is set to the top of the document, so the user wouldn't see it immediately. The page title also does not change to include `Error:`. The GOV.UK blog has some bespoke JS to scroll the user with an animation to the error summary. Instead, I think it would be easier if we had an error notice at the top of the page, and an error summary near the actual comment section~~ Somewhat addressed by adding a `turbo_frame`.

### Screenshots

#### Enabling comments in design history settings

![image](https://user-images.githubusercontent.com/1650875/234875249-5e6b5d9a-51d8-4e2a-9cda-e28301ab54cd.png)


#### Post with empty comments section

![image](https://user-images.githubusercontent.com/1650875/234844840-e3c5846e-188c-4516-b8aa-288e916bff3c.png)

#### Encountering an error

![image](https://user-images.githubusercontent.com/1650875/234845514-4808f7b9-e5ae-443b-9e24-530e8263440c.png)

#### Successfully submitting a comment

![image](https://user-images.githubusercontent.com/1650875/234845615-dd241900-07eb-4b85-aea8-f08ecf6a4fea.png)

#### Back-office admin

![image](https://user-images.githubusercontent.com/1650875/234845643-22743877-b35f-4bfb-9dc5-1c17cb55f6a4.png)
