### PR TITLE
Set OPENAI_ACCESS_TOKEN in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ RUN chmod +x /app/bin/* && \
 # as necessary.  If no combination works for you, see:
 # https://fly.io/docs/rails/getting-started/existing/#access-to-environment-variables-at-build-time
 ENV SECRET_KEY_BASE 1
+ENV OPENAI_ACCESS_TOKEN 1
 # ENV AWS_ACCESS_KEY_ID=1
 # ENV AWS_SECRET_ACCESS_KEY=1
 

--- a/app/services/spam_checker.rb
+++ b/app/services/spam_checker.rb
@@ -20,7 +20,7 @@ class SpamChecker
           model: "gpt-3.5-turbo",
           messages: [{ role: "user", content: prompt }],
           max_tokens: 1, # Reply with a single character, saves quota
-          temperature: 0, # Makes reply determinstic, same input = same output
+          temperature: 0, # Makes reply deterministic, same input = same output
           top_p: 1, # Also reduces randomness
           n: 1, # Return only one choice
           stream: false, # Don't stream response in


### PR DESCRIPTION
Without this, assets fail to precompile when building the docker image.

Also fix a typo in a comment.