### PR TITLE
Fix comments count, expose spam in Avo dashboard

### DIFF
--- a/app/avo/resources/comment_resource.rb
+++ b/app/avo/resources/comment_resource.rb
@@ -10,7 +10,6 @@ class CommentResource < Avo::BaseResource
   field :body, as: :textarea
   field :email, as: :text
   field :name, as: :text
-  field :commentable_id, as: :number
-  field :commentable_type, as: :text
+  field :spam, as: :boolean
   # add fields here
 end

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "comments" do %>
   <section>
     <% if post.comments.ham.any? %>
-      <h3><%= pluralize(post.comments.size, 'comment') %></h3>
+      <h3><%= pluralize(post.comments.ham.size, 'comment') %></h3>
       <ul class="govuk-list">
         <% post.comments.ham.each do |comment| %>
           <li id="comment-<%= comment.id %>">


### PR DESCRIPTION
We need to expose the `:spam` attribute in Avo to be able to edit it.

Also fixes the comments count on posts.