### PR TITLE
Add privacy notice

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,4 +10,8 @@ class PagesController < ApplicationController
     respond_to :text
     expires_in 6.hours, public: true
   end
+
+  def privacy_notice
+    render layout: "two-thirds"
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,10 +21,17 @@
 
       <%= f.govuk_submit "Create account", class: 'app-submit' %>
     <% end %>
+
+    <p>
+      If you already have an account you can
+      <%= govuk_link_to "sign in", new_session_path(resource_name) %>.
+    </p>
+
+    <%= govuk_inset_text do %>
+      By creating an account you understand that we may use your email to help
+      you to administer your account. Please read our
+      <%= link_to "privacy notice", privacy_path %> to see how the Design
+      History platform handles your information.
+    <% end %>
   <% end %>
 <% end %>
-
-<p>
-  If you already have an account you can
-  <%= govuk_link_to "sign in", new_session_path(resource_name) %>.
-</p>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -62,6 +62,8 @@
               <a class="govuk-footer__link"
                 href="https://github.com/design-history/design-history/">
                 Source code on GitHub</a>.
+              <%= link_to "Privacy notice", privacy_path,
+                class: "govuk-footer__link" %>.
             </p>
           </div>
         </div>

--- a/app/views/layouts/two-thirds.html.erb
+++ b/app/views/layouts/two-thirds.html.erb
@@ -1,0 +1,13 @@
+<% content_for :content do %>
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-width-container">
+      <%= govuk_row do %>
+        <%= govuk_two_thirds do %>
+          <%= yield %>
+        <% end %>
+      <% end %>
+    </div>
+  </main>
+<% end %>
+
+<%= render template: 'layouts/base' %>

--- a/app/views/pages/privacy_notice.md
+++ b/app/views/pages/privacy_notice.md
@@ -1,0 +1,101 @@
+# Privacy notice
+
+Last updated on: 28 April 2023
+
+The Design History website is a tool for people to blog about their work. It's
+provided by the [Design History team](https://github.com/design-history/).
+
+This privacy notice explains how we handle your personal data when using our
+platform.
+
+## What data we collect
+
+If you create a design history, we collect the following data:
+
+- your email address when you create an account
+- the content of your design history and your posts
+
+If you submit a comment on a design history post, we collect the following
+data:
+
+- email address
+- name
+- the content of your post
+
+## Why we need it
+
+We use your data to:
+
+- create a user account
+- allow you to leave a comment
+- know you're a real person and respond to your comments on posts
+
+We will not:
+
+- sell or rent your data to third parties
+- share your data with third parties for marketing purposes
+- use third-party analytics or invasive user tracking methods
+- display ads on our platform
+
+We will share your data if we are required to do so by law – for example, by
+court order, or to prevent fraud or other crime.
+
+## How long we keep your data
+
+We will retain your account and email data for as long as you continue to want
+to receive a service from us.
+
+## Children’s privacy protection
+
+Our services are not designed for, or intentionally targeted at, children 13
+years of age or younger. It is not our policy to intentionally collect or
+maintain data about anyone under the age of 13.
+
+## Where your data is processed and stored
+
+We design, build and run our systems to make sure that your data is as safe as
+possible at every stage, both while it’s processed and when it’s stored.
+
+Your personal data is stored on IT infrastructure in the United Kingdom.
+
+Comments are processed by OpenAI in the United States to identify spam.
+
+## How we protect your data and keep it secure
+
+We are committed to keeping your data secure. We set up systems and processes
+to prevent unauthorised access or disclosure of the data we collect about you.
+
+## Your rights
+
+You have the right to request:
+
+- information about how your personal data is processed
+- a copy of any personal data you have provided in an accessible format
+- that anything inaccurate in your personal data is corrected immediately
+
+You can also:
+
+- raise an objection about how your personal data is processed
+- request that your personal data is erased if there is no longer a
+  justification for it
+- ask that the processing of your personal data is restricted in certain
+  circumstances
+
+If you have any of these requests, get in contact with our team. Contact
+details can be found below.
+
+## Changes to this notice
+
+We may modify or amend this privacy notice at our discretion at any time. When
+we make changes to this notice, we will amend the last modified date at the top
+of this page. Any modification or amendment to this privacy notice will be
+applied to you and your data as of that revision date. If these changes affect
+how your personal data is processed, we will take reasonable steps to make sure
+you know.
+
+## How to contact us
+
+If you have any questions about this privacy notice or how we handle your
+personal data, please contact us at:
+
+[design-history-privacy@vararu.org](mailto:design-history-privacy@vararu.org)

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -41,5 +41,11 @@
 
       <%= f.govuk_submit "Submit comment" %>
     <% end %>
+
+    <%= govuk_inset_text do %>
+      By submitting a comment you understand it may be published on this public
+      website. Please read our <%= link_to "privacy notice", privacy_path %> to
+      see how the Design History platform handles your information.
+    <% end %>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get "/robots.:format", to: "pages#robots"
+  get "/privacy", to: "pages#privacy_notice"
 
   scope via: :all do
     get "/404", to: "errors#not_found"


### PR DESCRIPTION
This is a starter privacy notice for the service. Now that we're allowing comments, and those comments are processed by third parties (OpenAI), we should tell our users about this.

### Privacy notice

![image](https://user-images.githubusercontent.com/1650875/235156059-286fe921-35f3-4bfb-816b-8418cc5ebd15.png)

### Notice when commenting on a post

![image](https://user-images.githubusercontent.com/1650875/235154705-a498319c-301b-4dbb-b524-d252a010358b.png)

### Notice when creating an account

![image](https://user-images.githubusercontent.com/1650875/235154631-7367df71-5f9e-4045-96ac-e1b5a53db94b.png)

