### PR TITLE
Add "Save and preview" button to post edit form

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_project
-  before_action :set_post, only: %i[edit update destroy]
+  before_action :set_post, only: %i[edit preview update destroy]
   before_action :validate_published_at, only: [:update]
 
   # GET /posts
@@ -16,6 +16,10 @@ class PostsController < ApplicationController
 
   # GET /posts/1/edit
   def edit
+  end
+
+  # GET /posts/1/preview
+  def preview
   end
 
   # POST /posts

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -50,7 +50,11 @@ class PostsController < ApplicationController
         notice = "Changes saved"
       end
 
-      redirect_to edit_project_post_path(@project, @post), notice:
+      if params[:submit] == "preview"
+        redirect_to preview_project_post_path(@project, @post), notice:
+      else
+        redirect_to edit_project_post_path(@project, @post), notice:
+      end
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/post_images/index.html.erb
+++ b/app/views/post_images/index.html.erb
@@ -1,45 +1,9 @@
-<% title = @post.title %>
-<%= content_for :page_title, "Edit screenshots – #{title}" %>
-<% content_for :breadcrumbs do %>
-  <%= govuk_breadcrumbs(breadcrumbs: {
-    "Your design histories" => projects_path,
-    @project.title => project_path(@project),
-    title => nil
-  }) %>
-<% end %>
-
-<%= govuk_row do %>
-  <%= govuk_two_thirds do %>
-    <%= form_with(model: [@project, @post]) do |f| %>
-      <%= f.govuk_error_summary %>
-    <% end %>
-  <% end %>
-<% end %>
-
-<h1 class="govuk-heading-xl">
-  <% if @post.title %>
-    <span class="govuk-caption-xl">
-      <%= @post.published? ? 'Published post' : 'Draft post' %>
-    </span>
-  <% end %>
-  <%= title %>
-</h1>
+<%= render "shared/edit_post_header", project: @project, post: @post %>
 
 <div class="govuk-tabs">
-  <ul class="govuk-tabs__list">
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab"
-        href="<%= edit_project_post_path(@project, @post) %>">
-        Write
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-      <a class="govuk-tabs__tab"
-        href="<%= project_post_images_path(@project, @post) %>">
-        Screenshots
-      </a>
-    </li>
-  </ul>
+  <%= render "shared/edit_post_tabs", project: @project, post: @post,
+    tab: :screenshots %>
+
   <div class="govuk-tabs__panel">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Screenshots</h2>
     <p class="govuk-!-margin-bottom-6">

--- a/app/views/post_images/index.html.erb
+++ b/app/views/post_images/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Edit screenshots – #{@post.title}" %>
+
 <%= render "shared/edit_post_header", project: @project, post: @post %>
 
 <div class="govuk-tabs">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -34,5 +34,11 @@
       hint: { text: 'Defaults to today when published' } %>
   <% end %>
 
-  <%= f.govuk_submit "Save" %>
+  <%= f.govuk_submit "Save and preview", secondary: true,
+    value: "preview", name: "submit" %>
+
+  <br />
+
+  <%= f.govuk_submit "Save",
+    value: "save", name: "submit" %>
 <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,8 +1,10 @@
+<% content_for :page_title, "Edit post – #{@post.title}" %>
+
 <%= render "shared/edit_post_header", project: @project, post: @post %>
 
 <div class="govuk-tabs">
   <%= render "shared/edit_post_tabs", project: @project, post: @post,
-    tab: :write%>
+    tab: :write %>
 
   <div class="govuk-tabs__panel">
     <%= render "form", project: @project, post: @post %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,45 +1,9 @@
-<% title = @post.title %>
-<% content_for :page_title, "Edit post – #{title}" %>
-<% content_for :breadcrumbs do %>
-  <%= govuk_breadcrumbs(breadcrumbs: {
-    "Your design histories" => projects_path,
-    @project.title => project_path(@project),
-    title => nil
-  }) %>
-<% end %>
-
-<%= govuk_row do %>
-  <%= govuk_two_thirds do %>
-    <%= form_with(model: [@project, @post]) do |f| %>
-      <%= f.govuk_error_summary %>
-    <% end %>
-  <% end %>
-<% end %>
-
-<h1 class="govuk-heading-xl">
-  <% if @post.title %>
-    <span class="govuk-caption-xl">
-      <%= @post.published? ? 'Published post' : 'Draft post' %>
-    </span>
-  <% end %>
-  <%= title %>
-</h1>
+<%= render "shared/edit_post_header", project: @project, post: @post %>
 
 <div class="govuk-tabs">
-  <ul class="govuk-tabs__list">
-    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-      <a class="govuk-tabs__tab"
-        href="<%= edit_project_post_path(@project, @post) %>">
-        Write
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab"
-        href="<%= project_post_images_path(@project, @post) %>">
-        Screenshots
-      </a>
-    </li>
-  </ul>
+  <%= render "shared/edit_post_tabs", project: @project, post: @post,
+    tab: :write%>
+
   <div class="govuk-tabs__panel">
     <%= render "form", project: @project, post: @post %>
   </div>

--- a/app/views/posts/preview.html.erb
+++ b/app/views/posts/preview.html.erb
@@ -1,0 +1,16 @@
+<%= render "shared/edit_post_header", project: @project, post: @post %>
+
+<div class="govuk-tabs">
+  <%= render "shared/edit_post_tabs", project: @project, post: @post,
+    tab: :preview %>
+
+  <div class="govuk-tabs__panel">
+    <%= govuk_row do %>
+      <%= govuk_two_thirds do %>
+        <div class="app-markdown">
+          <%= GovukMarkdown.render(@post.body).html_safe %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/posts/preview.html.erb
+++ b/app/views/posts/preview.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Preview post – #{@post.title}" %>
+
 <%= render "shared/edit_post_header", project: @project, post: @post %>
 
 <div class="govuk-tabs">

--- a/app/views/shared/_edit_post_header.html.erb
+++ b/app/views/shared/_edit_post_header.html.erb
@@ -1,5 +1,3 @@
-<% title = post.title %>
-<% content_for :page_title, "Edit screenshots – #{title}" %>
 <% content_for :breadcrumbs do %>
   <%= govuk_breadcrumbs(breadcrumbs: {
     "Your design histories" => projects_path,
@@ -22,5 +20,5 @@
       <%= post.published? ? 'Published post' : 'Draft post' %>
     </span>
   <% end %>
-  <%= title %>
+  <%= post.title %>
 </h1>

--- a/app/views/shared/_edit_post_header.html.erb
+++ b/app/views/shared/_edit_post_header.html.erb
@@ -1,0 +1,26 @@
+<% title = post.title %>
+<% content_for :page_title, "Edit screenshots – #{title}" %>
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: {
+    "Your design histories" => projects_path,
+    project.title => project_path(project),
+    title => nil
+  }) %>
+<% end %>
+
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <%= form_with(model: [project, post]) do |f| %>
+      <%= f.govuk_error_summary %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  <% if post.title %>
+    <span class="govuk-caption-xl">
+      <%= post.published? ? 'Published post' : 'Draft post' %>
+    </span>
+  <% end %>
+  <%= title %>
+</h1>

--- a/app/views/shared/_edit_post_tabs.html.erb
+++ b/app/views/shared/_edit_post_tabs.html.erb
@@ -1,0 +1,25 @@
+<ul class="govuk-tabs__list">
+  <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if tab == :write %>">
+    <% if tab == :write %>
+      Write
+    <% else %>
+      <%= link_to "Write", edit_project_post_path(project, post),
+        class: "govuk-tabs__tab" %>
+    <% end %>
+  </li>
+
+  <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if tab == :screenshots %>">
+    <% if tab == :screenshots %>
+      Screenshots
+    <% else %>
+      <%= link_to "Screenshots", project_post_images_path(project, post),
+        class: "govuk-tabs__tab" %>
+    <% end %>
+  </li>
+
+  <% if tab == :preview %>
+    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+      Preview
+    </li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
           post :up, on: :member
           post :down, on: :member
         end
+
+        get "/preview", to: "posts#preview", on: :member
       end
     end
 

--- a/spec/system/preview_spec.rb
+++ b/spec/system/preview_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Preview" do
+  it "lets users preview draft posts" do
+    given_i_am_signed_in
+    when_i_visit_my_post
+    then_i_see_the_preview_button
+
+    when_i_edit_the_post
+    and_i_click_the_preview_button
+    then_i_see_the_preview_with_the_edit
+  end
+
+  private
+
+  def given_i_am_signed_in
+    @owner = create(:user)
+    sign_in @owner
+  end
+
+  def when_i_visit_my_post
+    @project = create(:project, owner: @owner)
+    @post = create(:post, project: @project)
+    visit edit_project_post_path(@project, @post)
+  end
+
+  def then_i_see_the_preview_button
+    expect(page).to have_button "Save and preview"
+  end
+
+  def when_i_edit_the_post
+    fill_in "Post", with: "New content"
+  end
+
+  def and_i_click_the_preview_button
+    click_button "Save and preview"
+  end
+
+  def then_i_see_the_preview_with_the_edit
+    expect(page).to have_content "New content"
+  end
+end


### PR DESCRIPTION
This adds a new "Preview" tab.

Because we need to save a version of the post in order to preview it, instead of adding the link to the tab headers, I decided to make it into a button on the actual form itself. That way it's hopefully more obvious to the user that saving a published post would immediately update the live one...

We should revisit the preview feature later with a more thorough data model, like actual post versions. However, until then, this should be a good stop-gap to help with previewing posts while writing them.

### New "Save and preview" button

![image](https://user-images.githubusercontent.com/1650875/235464514-05898ca3-ba38-442c-b445-aa24a2a5c94b.png)

### The preview tab

The tab "disappears" when you navigate back to the Write or Screenshots sections.

![image](https://user-images.githubusercontent.com/1650875/235464544-13e24d0f-c2f9-4cc9-a44d-1e1104659055.png)
