### PR TITLE
Fix breadcrumb on post edit

### DIFF
--- a/app/views/shared/_edit_post_header.html.erb
+++ b/app/views/shared/_edit_post_header.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_breadcrumbs(breadcrumbs: {
     "Your design histories" => projects_path,
     project.title => project_path(project),
-    title => nil
+    post.title => nil
   }) %>
 <% end %>
 


### PR DESCRIPTION
This was broken in https://github.com/design-history/design-history/pull/304/commits/f80a69f453c6273563b8fd33dbbeb7067803fd77#diff-005f7ad34f8f1c371fb65b6fb0dff00d3627a023bd4f06885809ce7cf20f8423R7

Fixes https://github.com/design-history/design-history/issues/317