### PR TITLE
Bump node tool version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 ruby 3.1.2
-nodejs 18.1.0
+nodejs 18.12.0
 yarn 1.22.19
 postgres 13.5


### PR DESCRIPTION
Deploys are failing because `yarn` has been upgraded to 4.0.0 on CI which requires Node v18.12.0 or higher.