### PR TITLE
Allow users to display emails in posts

### DIFF
--- a/app/assets/stylesheets/_email.scss
+++ b/app/assets/stylesheets/_email.scss
@@ -1,0 +1,45 @@
+.app-email {
+  @include govuk-font($size: false);
+  border: $govuk-border-width solid $govuk-border-colour;
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(8);
+  max-width: 40rem;
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    @include govuk-font($size: 27, $weight: bold);
+    margin-bottom: govuk-spacing(4);
+  }
+}
+
+.app-email-headers {
+  @include govuk-font($size: 19);
+  margin-top: 0;
+  margin-bottom: govuk-spacing(4);
+  border-bottom: 1px solid $govuk-border-colour;
+
+  &__row {
+    justify-content: left;
+    display: flex;
+    margin-bottom: govuk-spacing(2);
+  }
+
+  &__key {
+    color: $govuk-secondary-text-colour;
+    font-weight: normal;
+    min-width: 5em;
+  }
+
+  &__value {
+    font-weight: normal;
+    margin: 0;
+  }
+
+  // For some reason, the markdown renderer adds a superfluous <p> tag.
+  // This is a hack to hide it.
+  p:last-child {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -75,4 +75,8 @@ $govuk-button-background-colour: $app-button-colour;
     max-width: 100%;
     outline: 1px solid rgba(177, 180, 182, 0.5);
   }
+
+  pre {
+    white-space: pre-wrap;
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@ $govuk-button-background-colour: $app-button-colour;
 @import "govuk-frontend/govuk/all";
 
 @import "button-link";
+@import "email";
 @import "footer";
 @import "global";
 @import "header";

--- a/config/initializers/govuk_markdown_extension.rb
+++ b/config/initializers/govuk_markdown_extension.rb
@@ -1,3 +1,21 @@
+module GovukMarkdownExtension
+  def render(markdown, govuk_options = {})
+    renderer = GovukMarkdown::Renderer.new(govuk_options, {
+      with_toc_data: true,
+      link_attributes: { class: "govuk-link" }
+    })
+
+    Redcarpet::Markdown
+      .new(renderer, {
+        tables: true,
+        highlight: true,
+        no_intra_emphasis: true,
+        fenced_code_blocks: true
+      })
+      .render(markdown).strip
+  end
+end
+
 module PreprocessorExtension
   def inject_email
     sections = @output.split("```")
@@ -59,5 +77,6 @@ module RendererExtension
   end
 end
 
+GovukMarkdown.singleton_class.prepend(GovukMarkdownExtension)
 GovukMarkdown::Preprocessor.prepend(PreprocessorExtension)
 GovukMarkdown::Renderer.prepend(RendererExtension)

--- a/config/initializers/govuk_markdown_extension.rb
+++ b/config/initializers/govuk_markdown_extension.rb
@@ -1,0 +1,63 @@
+module PreprocessorExtension
+  def inject_email
+    sections = @output.split("```")
+    sections.each_with_index do |section, index|
+      next if index.odd?
+
+      section.gsub!(build_regexp("email")) do
+        content = Regexp.last_match(1)
+        headers, body = construct_email_from(content)
+        <<~HTML
+          <div class="app-email">
+            <dl class="app-email-headers">
+              #{headers.map { |k, v| email_header_row(k, v) }.join("")}
+            </dl>
+            #{nested_markdown(body)}
+          </div>
+        HTML
+      end
+    end
+
+    @output = sections.join("```")
+    self
+  end
+
+  private
+
+  def construct_email_from(match_string)
+    headers = {}
+
+    header, body = match_string.split(/^-{3,}\n?/, 2)
+
+    header_regex = /^(.*?):\s*(.*?)\s*$/
+    header.each_line do |line|
+      matches = header_regex.match(line)
+      headers[matches[1]] = matches[2] if matches
+    end
+
+    body.gsub!(/(\(\()(.*?)(\)\))/, '\1==\2==\3')
+
+    [headers, body]
+  end
+
+  def email_header_row(key, value)
+    <<~HTML
+      <div class="app-email-headers__row">
+        <dt class="app-email-headers__key">#{key}</dt>
+        <dd class="app-email-headers__value">#{value}</dd>
+      </div>
+    HTML
+  end
+end
+
+module RendererExtension
+  def preprocess(document)
+    GovukMarkdown::Preprocessor
+      .new(document)
+      .inject_email
+      .output
+  end
+end
+
+GovukMarkdown::Preprocessor.prepend(PreprocessorExtension)
+GovukMarkdown::Renderer.prepend(RendererExtension)


### PR DESCRIPTION
This extends the markdown renderer to allow users to display inline email illustrations.

The markdown for an email is as such:

```
{email}
Subject: We've added support for showing emails
From: hello@designhistory.io
To: user@example.com
---
Dear ((user)),

We've extended the markdown renderer in the [Design History app](https://designhistory.io/).

For more information, read our blog post: [https://this.designhistory.app/showing-transactional-emails](https://this.designhistory.app/showing-transactional-emails)

Regards,<br />
The Design History team
{/email}
```

A design history post will provide some more context.

## Bonus: Add support for fenced code blocks and highlights

Users can now use triple backticks to delineate code blocks, and double equals to ==highlight== words.

## Screenshot

![image](https://github.com/design-history/design-history/assets/1650875/0d040c4e-0d6c-4829-83a3-746c1f095249)