### PR TITLE
Make headers optional in email markdown

### DIFF
--- a/spec/initializers/govuk_markdown_spec.rb
+++ b/spec/initializers/govuk_markdown_spec.rb
@@ -19,21 +19,39 @@ describe 'GovukMarkdownExtension' do
     expect(rendered_text).to include('<mark>')
   end
 
-  it 'renders emails' do
-    markdown = <<~MD
-      {email}
-      Subject: This is a subject
-      To: foo@example.com
-      ---
-      # This is the body
+  describe 'emails' do
+    it 'render correctly' do
+      markdown = <<~MD
+        {email}
+        Subject: This is a subject
+        To: foo@example.com
+        ---
+        # This is the body
 
-      With some markdown, and a ((placeholder))
-      {/email}
-    MD
-    rendered_text = GovukMarkdown.render(markdown)
-    expect(rendered_text).to include('<div class="app-email">')
-    expect(rendered_text).to include('<h1')
-    expect(rendered_text).to include('<mark>placeholder</mark>')
+        With some markdown, and a ((placeholder))
+        {/email}
+      MD
+      rendered_text = GovukMarkdown.render(markdown)
+      expect(rendered_text).to include('<div class="app-email">')
+      expect(rendered_text).to include('<dl class="app-email-headers">')
+      expect(rendered_text).to include('<h1')
+      expect(rendered_text).to include('<mark>placeholder</mark>')
+    end
+
+    it 'render correctly when header is missing' do
+      markdown = <<~MD
+        {email}
+        # This is the body
+
+        With some markdown, and a ((placeholder))
+        {/email}
+      MD
+      rendered_text = GovukMarkdown.render(markdown)
+      expect(rendered_text).to include('<div class="app-email">')
+      expect(rendered_text).not_to include('<dl class="app-email-headers">')
+      expect(rendered_text).to include('<h1')
+      expect(rendered_text).to include('<mark>placeholder</mark>')
+    end
   end
 
   it "doesn't render emails when they're in a code block" do


### PR DESCRIPTION
If there are no headers specified, then the whole content of the email is assumed to be the body.