### PR TITLE
Use ‘smart’ punctuation for apostrophe

### DIFF
--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -37,7 +37,7 @@
         label: { text: 'Name' } %>
       <%= f.govuk_text_field :email,
         label: { text: 'Email' },
-        hint: { text: 'We only ask for your email so we know you\'re a real person' } %>
+        hint: { text: 'We only ask for your email so we know you’re a real person' } %>
 
       <%= f.govuk_submit "Submit comment" %>
     <% end %>


### PR DESCRIPTION
Smart quotes for smart people. 💅