### PR TITLE
Iterate team page design

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -4,7 +4,6 @@ class TeamsController < ApplicationController
 
   # GET /teams/1
   def show
-    @add_user_form = AddUserForm.new
   end
 
   # GET /teams/new
@@ -23,14 +22,19 @@ class TeamsController < ApplicationController
     end
   end
 
-  # POST /teams/1/add-user
+  # GET /teams/1/add-user
   def add_user
+    @add_user_form = AddUserForm.new
+  end
+
+  # POST /teams/1/add-user
+  def add_user_create
     @add_user_form = AddUserForm.new(add_user_params)
     @add_user_form.team = @team
     if @add_user_form.save
       redirect_to @team, notice: "User added"
     else
-      render :show, status: :unprocessable_entity
+      render :add_user, status: :unprocessable_entity
     end
   end
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -31,6 +31,13 @@
 
         <% if admin && current_user %>
           <ul id="navigation" class="govuk-header__navigation-list">
+            <% if current_user.team.present? %>
+              <li class="govuk-header__navigation-item
+                         app-header__navigation-item">
+                <%= link_to "Your team", team_path(current_user.team),
+                  class: 'govuk-header__link' %>
+              </li>
+            <% end %>
             <li class="govuk-header__navigation-item
                        app-header__navigation-item">
               <%= link_to "Your design histories", projects_path,

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -6,7 +6,7 @@
         <% if editing %>
           Edit <%= team.name %>
         <% else %>
-          New team
+          Create a new team
         <% end %>
       </h1>
 
@@ -15,7 +15,7 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>only be part of one team</li>
           <li>invite others to your team</li>
-          <li>give a team ownership of your design histories</li>
+          <li>transfer ownership of your design histories to a team</li>
         </ul>
       <% end %>
 

--- a/app/views/teams/add_user.html.erb
+++ b/app/views/teams/add_user.html.erb
@@ -1,0 +1,26 @@
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: {
+    "Your team" => team_path(@team),
+    "Add a user to your team" => nil
+  }) %>
+<% end %>
+
+<% title = "Add a user to your team" %>
+<%= content_for :page_title, title %>
+
+<%= govuk_row do %>
+  <%= govuk_two_thirds do %>
+    <%= form_with(model: @add_user_form, url: add_user_team_path(@team)) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l"><%= title %></h1>
+
+      <p>To add a user they must have an account and not be part of a team.</p>
+
+      <%= f.govuk_text_field :email,
+        label: { class: 'govuk-label govuk-label--s' } %>
+
+      <%= f.govuk_submit "Add user to team" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,39 +1,67 @@
-<% title = "#{@team.name} team settings" %>
+<% title = "#{@team.name} team" %>
 <%= content_for :page_title, title %>
 
-<%= govuk_row do %>
-  <%= govuk_two_thirds do %>
-    <%= form_with(model: @add_user_form, url: add_user_team_path(@team)) do |f| %>
-      <%= f.govuk_error_summary %>
+<h1 class="govuk-heading-xl"><%= title %></h1>
 
-      <h1 class="govuk-heading-xl"><%= title %></h1>
+<section class="app-summary-card govuk-!-margin-bottom-6">
+  <header class="app-summary-card__header">
+    <h2 class="app-summary-card__title govuk-!-font-weight-bold govuk-!-font-size-24">
+      Team settings
+    </h2>
+  </header>
 
-      <h2>Users</h2>
+  <div class="app-summary-card__body">
+    <%= govuk_summary_list do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { "Name" }
+        row.with_value { @team.name }
+      end
 
-      <ul class="govuk-list govuk-list--bullet">
-        <% @team.users.each do |user| %>
-          <li><%= user.email %></li>
-        <% end %>
-      </ul>
+      summary_list.with_row do |row|
+        row.with_key { "Users" }
+        row.with_value { @team.users.map(&:email).join(", ") }
+        row.with_action(text: "Add a new user",
+                        href: add_user_team_path(@team))
+      end
+    end %>
+  </div>
+</section>
 
-      <% if @team.projects.any? %>
-        <h2>Projects</h2>
+<section class="app-summary-card govuk-!-margin-bottom-6">
+  <header class="app-summary-card__header">
+    <h2 class="app-summary-card__title govuk-!-font-weight-bold govuk-!-font-size-24">
+      Design histories
+    </h2>
+  </header>
 
-        <ul class="govuk-list govuk-list--bullet">
-          <% @team.projects.each do |project| %>
-            <li><%= govuk_link_to project.title, project %></li>
-          <% end %>
-        </ul>
-      <% end %>
+  <div class="app-summary-card__body">
+    <% if @team.projects.any? %>
+      <%= govuk_table do |table|
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell(text: 'Title', header: true)
+            row.with_cell(text: 'Description', header: true)
+            row.with_cell(text: 'Visibility', header: true)
+          end
+        end
 
-      <h2>Add users to this team</h2>
-
-      <p>To add a user they must have an account and not be part of a team.</p>
-
-      <%= f.govuk_text_field :email,
-        label: { class: 'govuk-label govuk-label--s' } %>
-
-      <%= f.govuk_submit "Add user to team" %>
+        table.with_body do |body|
+          @team.projects.each do |project|
+            body.with_row do |row|
+              row.with_cell { govuk_link_to project.title,
+                         project_path(project) }
+              row.with_cell { project.description }
+              row.with_cell { project.private? ?
+                              govuk_tag(text: "Private", colour: "grey") :
+                              govuk_tag(text: "Public", colour: "turquoise") }
+            end
+          end
+        end
+      end %>
+    <% else %>
+      <p class="govuk-!-margin-bottom-1">
+        You haven’t created any projects.
+      </p>
     <% end %>
-  <% end %>
-<% end %>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,8 @@ Rails.application.routes.draw do
     devise_for :users
 
     resources :teams do
-      post "/add-user", action: :add_user, on: :member
+      get "/add-user", action: :add_user, on: :member
+      post "/add-user", action: :add_user_create, on: :member
       post "/add-project", action: :add_project, on: :member
     end
 

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Teams" do
   end
 
   def then_i_see_the_create_a_team_page
-    expect(page).to have_content "New team"
+    expect(page).to have_content "Create a new team"
   end
 
   def when_i_submit_a_name

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe "Teams" do
     when_i_submit_a_name
     then_i_see_the_team_show_page
 
+    when_i_click_on_add_user
+    then_i_see_the_add_user_page
+
     when_i_submit_an_invalid_email
     then_i_see_an_error
 
@@ -117,5 +120,13 @@ RSpec.describe "Teams" do
 
   def then_i_see_a_success_message
     expect(page).to have_content "Success"
+  end
+
+  def when_i_click_on_add_user
+    click_link "Add a new user"
+  end
+
+  def then_i_see_the_add_user_page
+    expect(page).to have_content "Add a user to your team"
   end
 end


### PR DESCRIPTION
This splits out the "Add new user" form to its own page and uses a design that's more similar to the one on the Design history show page.

### Before

![image](https://github.com/design-history/design-history/assets/1650875/db9a9ea1-dda5-4b6c-bb8d-1f7d5dc5bc17)

### After

![image](https://github.com/design-history/design-history/assets/1650875/d6a31e9d-a6ba-40ed-88f3-fee161b1dbb3)

![image](https://github.com/design-history/design-history/assets/1650875/98d01d6b-67a8-442e-a165-410fd9f3a3f7)
