### PR TITLE
Wrap post titles in two_thirds 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,6 +40,10 @@ or set it with content_for(:page_title)."
     tag.div(class: "govuk-grid-column-two-thirds-from-desktop", &block)
   end
 
+  def govuk_one_half(&block)
+    tag.div(class: "govuk-grid-column-one-half-from-desktop", &block)
+  end
+
   def is_admin?
     request.domain == Rails.application.config.admin_domain
   end

--- a/app/views/app/show.html.erb
+++ b/app/views/app/show.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <%= govuk_row do %>
-  <div class="govuk-grid-column-full">
+  <%= govuk_two_thirds do %>
     <header class="app-document-header">
       <%= h1 page_title: "#{@post.title} - #{@project.title}",
              class: "app-document-header__title govuk-heading-xl" do %>
@@ -32,8 +32,10 @@
         <%= govuk_tag(text: "Draft", colour: "grey") %>
       <% end %>
     </aside>
-  </div>
+  <% end %>
+<% end %>
 
+<%= govuk_row do %>
   <%= govuk_two_thirds do %>
     <article class="app-markdown">
       <%= GovukMarkdown.render(@post.body).html_safe %>


### PR DESCRIPTION
This looks better for posts with long titles.

![Screenshot 2023-12-13 at 11 40 46](https://github.com/design-history/design-history/assets/1650875/9bd48228-971d-4285-a0d5-b813d11fc4a0)

