### PR TITLE
Add groups

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -28,7 +28,7 @@ class ProjectsController < ApplicationController
   def create
     @project = current_user.own_projects.new(project_params)
     if @project.save
-      redirect_to @project, notice: "Your design history has been created"
+      redirect_to @project, notice: "Your #{@project.label} has been created"
     else
       render :new, status: :unprocessable_entity
     end
@@ -46,7 +46,7 @@ class ProjectsController < ApplicationController
   # DELETE /projects/1
   def destroy
     @project.destroy!
-    redirect_to projects_url, notice: "Your design history has been deleted"
+    redirect_to projects_url, notice: "Your #{@project.label} has been deleted"
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -17,7 +17,11 @@ class ProjectsController < ApplicationController
 
   # GET /projects/new
   def new
-    @project = current_user.own_projects.new
+    @project = if params[:type] == "group"
+      current_user.own_groups.new
+    else
+      current_user.own_projects.new
+    end
   end
 
   # GET /projects/1/edit

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,8 @@ class ProjectsController < ApplicationController
 
   # GET /projects
   def index
-    @projects = current_user.projects.all.order(:title)
+    @projects = current_user.projects.where(type: nil).order(:title)
+    @groups = current_user.groups.all.order(:title)
   end
 
   # GET /projects/1

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -45,7 +45,7 @@ class TeamsController < ApplicationController
     project = Project.find(add_project_params)
     project.update!(owner: @team)
     redirect_to project_manage_access_path(project),
-                notice: "Design history was added to your team"
+      notice: "#{project.label.upcase_first} was added to your team"
   end
 
   private

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -15,11 +15,18 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  owner_id         :bigint           not null
+#  project_id       :bigint
 #
 # Indexes
 #
-#  index_projects_on_owner      (owner_type,owner_id)
-#  index_projects_on_subdomain  (subdomain) UNIQUE
+#  index_projects_on_owner       (owner_type,owner_id)
+#  index_projects_on_project_id  (project_id)
+#  index_projects_on_subdomain   (subdomain) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
 #
 class Group < Project
+  has_many :projects, foreign_key: :project_id
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < Project
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,2 +1,25 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id               :bigint           not null, primary key
+#  comments_enabled :boolean          default(FALSE)
+#  description      :string
+#  owner_type       :string           not null
+#  password         :string
+#  related_links    :text             default("")
+#  subdomain        :string
+#  theme            :string           default("dh"), not null
+#  title            :string
+#  type             :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  owner_id         :bigint           not null
+#
+# Indexes
+#
+#  index_projects_on_owner      (owner_type,owner_id)
+#  index_projects_on_subdomain  (subdomain) UNIQUE
+#
 class Group < Project
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,17 +15,27 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  owner_id         :bigint           not null
+#  project_id       :bigint
 #
 # Indexes
 #
-#  index_projects_on_owner      (owner_type,owner_id)
-#  index_projects_on_subdomain  (subdomain) UNIQUE
+#  index_projects_on_owner       (owner_type,owner_id)
+#  index_projects_on_project_id  (project_id)
+#  index_projects_on_subdomain   (subdomain) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
 #
 class Project < ApplicationRecord
   belongs_to :owner, polymorphic: true
   has_many :posts, dependent: :destroy
 
   attr_accessor :visibility
+
+  scope :ungrouped, -> { where(project_id: nil, type: nil) }
+
+  belongs_to :group, foreign_key: :project_id, optional: true
 
   validates :title, presence: true, length: { maximum: 255 }
   validates :subdomain,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -62,6 +62,10 @@ class Project < ApplicationRecord
     password.present?
   end
 
+  def label
+    type&.downcase || "design history"
+  end
+
   private
 
   def strip_domain_and_protocol_from_subdomain

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,6 +11,7 @@
 #  subdomain        :string
 #  theme            :string           default("dh"), not null
 #  title            :string
+#  type             :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  owner_id         :bigint           not null

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -44,7 +44,8 @@ class Project < ApplicationRecord
   validates :password, presence: true, if: -> { visibility == "private" }
   validates :theme, inclusion: { in: %w[dh gov nhs] }
   before_validation :strip_domain_and_protocol_from_subdomain,
-                    on: %i[create update]
+                    on: %i[create update],
+                    if: -> { subdomain.present? }
 
   def private?
     password.present?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,6 +10,7 @@
 class Team < ApplicationRecord
   has_many :users
   has_many :projects, as: :owner
+  has_many :groups, as: :owner
 
   validates :name, presence: true, length: { maximum: 50 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,4 +51,16 @@ class User < ApplicationRecord
   def team_projects
     Project.where owner: team
   end
+
+  def groups
+    own_groups.or team_groups
+  end
+
+  def own_groups
+    Group.where owner: self
+  end
+
+  def team_groups
+    Group.where owner: team
+  end
 end

--- a/app/views/manage_access/edit.html.erb
+++ b/app/views/manage_access/edit.html.erb
@@ -13,7 +13,7 @@
   <%= h1 "Manage access", class: "govuk-heading-xl" %>
 
   <%= f.govuk_radio_buttons_fieldset(:visibility,
-      legend: { size: 'm', text: 'Who can see this design history' }) do %>
+    legend: { size: 'm', text: "Who can see this #{@project.label}) do %>
     <%= f.govuk_radio_button :visibility, 'public',
       checked: @project.password.blank? || @project.visibility == 'public',
       label: { text: 'Everyone (public)' },
@@ -32,13 +32,13 @@
 <h2>Teams</h2>
 
 <% if @project.owner == current_user.team %>
-  <p>This design history belongs to your team. Anyone can edit.</p>
+  <p>This <%= @project.label %> belongs to your team. Anyone can edit.</p>
 <% else %>
-  <p>This design history belongs to you. Only you can edit it.</p>
+  <p>This <%= @project.label %> belongs to you. Only you can edit it.</p>
 
   <% if current_user.team.present? %>
     <p>
-      You can add this design history to your team.
+      You can add this <%= @project.label %> to your team.
     </p>
 
     <%= govuk_button_to "Add to team",

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -45,7 +45,7 @@
         row.with_key { 'Visibility' }
         row.with_value { @project.private? ? "Private" : "Public" }
         row.with_action(text: "Manage access",
-                   href: project_manage_access_path(@project))
+                        href: project_manage_access_path(@project))
       end
     end %>
   </div>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,4 +1,5 @@
-<%= form_with(model: project) do |f| %>
+<%= form_with(url: projects_path(type: project.type.downcase),
+              model: project) do |f| %>
   <%= f.govuk_error_summary %>
 
   <% if project.persisted? %>
@@ -32,10 +33,13 @@
       class: 'govuk-label govuk-label--s'
     }
   %>
-  <%= f.govuk_text_area :related_links, rows: 4,
-    label: { text: 'Related content', size: 's' },
-    hint: { text: 'Use markdown for links. These will appear in the
-                   sidebar' } %>
+
+  <% unless project.kind_of?(Group) %>
+    <%= f.govuk_text_area :related_links, rows: 4,
+      label: { text: 'Related content', size: 's' },
+      hint: { text: 'Use markdown for links. These will appear in the
+                     sidebar' } %>
+  <% end %>
 
   <% themes = [
     OpenStruct.new(id: 'gov', name: 'UK Government'),
@@ -48,7 +52,7 @@
     :name,
     legend: { text: "Pick a #{project.label} style" } %>
 
-  <% if project.persisted? %>
+  <% if project.persisted? && !project.kind_of?(Group) %>
     <% legend = -> {
       tag.legend class: 'govuk-fieldset__legend govuk-fieldset__legend--m' do
         [tag.span("Comments"), govuk_tag(text: "Beta", colour: "blue")]

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -2,13 +2,13 @@
   <%= f.govuk_error_summary %>
 
   <% if project.persisted? %>
-    <%= h1 page_title: "Change design history details",
+    <%= h1 page_title: "Change #{project.label} details",
            class: "govuk-heading-l" do %>
       <span class="govuk-caption-l"><%= project.title %></span>
       Change details
     <% end %>
   <% else %>
-    <%= h1 "New design history", class: "govuk-heading-l" %>
+    <%= h1 "New #{project.label}", class: "govuk-heading-l" %>
   <% end %>
 
   <%= f.govuk_text_field :title,
@@ -20,7 +20,7 @@
     } %>
   <%= f.govuk_text_field :subdomain,
     label: {
-      text: 'Design history subdomain',
+      text: "#{project.label.upcase_first} subdomain",
       class: 'govuk-label govuk-label--s'
     },
     hint: {
@@ -46,7 +46,7 @@
     themes,
     :id,
     :name,
-    legend: { text: 'Pick a design history style' } %>
+    legend: { text: "Pick a #{project.label} style" } %>
 
   <% if project.persisted? %>
     <% legend = -> {
@@ -79,5 +79,5 @@
   <% end %>
 
   <%= f.govuk_submit project.persisted? ? "Save changes" :
-                                          "Create design history" %>
+                                          "Create #{project.label}" %>
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -48,32 +48,34 @@
     :name,
     legend: { text: 'Pick a design history style' } %>
 
-  <% legend = -> {
-    tag.legend class: 'govuk-fieldset__legend govuk-fieldset__legend--m' do
-      [tag.span("Comments"), govuk_tag(text: "Beta", colour: "blue")]
-        .join(" ").html_safe
-    end
-  } %>
+  <% if project.persisted? %>
+    <% legend = -> {
+      tag.legend class: 'govuk-fieldset__legend govuk-fieldset__legend--m' do
+        [tag.span("Comments"), govuk_tag(text: "Beta", colour: "blue")]
+          .join(" ").html_safe
+      end
+    } %>
 
-  <%= f.govuk_check_boxes_fieldset :comments_enabled,
-    multiple: false,
-    legend: legend do %>
-    <p>
-      Comments are in beta. We're still building out their functionality.
-    </p>
+    <%= f.govuk_check_boxes_fieldset :comments_enabled,
+      multiple: false,
+      legend: legend do %>
+      <p>
+        Comments are in beta. We're still building out their functionality.
+      </p>
 
-    <p>Currently, comments are:</p>
+      <p>Currently, comments are:</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>public</li>
-      <li>not moderated</li>
-      <li>not threaded</li>
-      <li>not editable</li>
-      <li>not deletable</li>
-    </ul>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>public</li>
+        <li>not moderated</li>
+        <li>not threaded</li>
+        <li>not editable</li>
+        <li>not deletable</li>
+      </ul>
 
-    <%= f.govuk_check_box :comments_enabled, 1, 0, multiple: false,
-      link_errors: true, label: { text: 'Enable comments' } %>
+      <%= f.govuk_check_box :comments_enabled, 1, 0, multiple: false,
+        link_errors: true, label: { text: 'Enable comments' } %>
+    <% end %>
   <% end %>
 
   <%= f.govuk_submit project.persisted? ? "Save changes" :

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,12 +1,13 @@
-<%= h1 "Your design histories", class: "govuk-heading-l" %>
+<%= h1 "Your design histories and groups", class: "govuk-heading-l" %>
 
 <% if @projects.any? %>
+  <h2 class="govuk-heading-m govuk-visually-hidden">Design histories</h2>
   <ul class="govuk-list govuk-!-margin-bottom-6">
     <% @projects.each do |project| %>
       <li>
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
           <%= govuk_link_to project.title, project_path(project) %>
-        </h2>
+        </h3>
         <p>
           <%= project.description %>
         </p>
@@ -15,6 +16,30 @@
   </ul>
   <p>
     <%= govuk_button_link_to "New design history", new_project_path %>
+  </p>
+
+  <h2 class="govuk-heading-m">Groups</h2>
+  <% if @groups.empty? %>
+    <p>
+      Groups are a way to organise and present your design histories. They have
+      their own domain and link to your design histories.
+    </p>
+  <% else %>
+    <ul class="govuk-list govuk-!-margin-bottom-6">
+      <% @groups.each do |group| %>
+        <li>
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
+            <%= govuk_link_to group.title, project_path(group) %>
+          </h3>
+          <p>
+            <%= group.description %>
+          </p>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+  <p>
+    <%= govuk_button_link_to "New group", new_project_path(type: "group") %>
   </p>
 <% else %>
   <p class="govuk-body">

--- a/db/migrate/20231219075213_add_type_to_project.rb
+++ b/db/migrate/20231219075213_add_type_to_project.rb
@@ -1,0 +1,5 @@
+class AddTypeToProject < ActiveRecord::Migration[7.1]
+  def change
+    add_column :projects, :type, :string
+  end
+end

--- a/db/migrate/20240131203704_add_project_id_to_projects.rb
+++ b/db/migrate/20240131203704_add_project_id_to_projects.rb
@@ -1,0 +1,5 @@
+class AddProjectIdToProjects < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :projects, :project, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_19_203028) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_19_075213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -172,6 +172,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_19_203028) do
     t.string "theme", default: "dh", null: false
     t.text "related_links", default: ""
     t.boolean "comments_enabled", default: false
+    t.string "type"
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_19_075213) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_31_203704) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -173,7 +173,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_19_075213) do
     t.text "related_links", default: ""
     t.boolean "comments_enabled", default: false
     t.string "type"
+    t.bigint "project_id"
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner"
+    t.index ["project_id"], name: "index_projects_on_project_id"
     t.index ["subdomain"], name: "index_projects_on_subdomain", unique: true
   end
 
@@ -206,5 +208,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_19_075213) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "posts", "projects"
+  add_foreign_key "projects", "projects"
   add_foreign_key "users", "teams"
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -11,14 +11,21 @@
 #  subdomain        :string
 #  theme            :string           default("dh"), not null
 #  title            :string
+#  type             :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  owner_id         :bigint           not null
+#  project_id       :bigint
 #
 # Indexes
 #
-#  index_projects_on_owner      (owner_type,owner_id)
-#  index_projects_on_subdomain  (subdomain) UNIQUE
+#  index_projects_on_owner       (owner_type,owner_id)
+#  index_projects_on_project_id  (project_id)
+#  index_projects_on_subdomain   (subdomain) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
 #
 FactoryBot.define do
   factory :project do

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -8,6 +8,21 @@ RSpec.describe "Groups" do
 
     when_i_click_the_new_group_button
     then_i_see_the_new_group_form
+
+    when_i_fill_in_and_submit_the_form
+    then_i_see_the_group_page
+
+    when_i_edit_the_group
+    then_i_see_the_edit_group_form
+
+    when_i_change_the_title_and_submit_the_form
+    then_i_see_the_updated_group_page
+
+    when_i_click_the_add_project_link
+    then_i_see_the_add_project_form
+
+    when_i_choose_a_project_and_submit_the_form
+    then_i_see_the_project_on_the_group_page
   end
 
   private
@@ -36,5 +51,51 @@ RSpec.describe "Groups" do
 
   def then_i_see_the_new_group_form
     expect(page).to have_content "New group"
+  end
+
+  def when_i_fill_in_and_submit_the_form
+    fill_in "Title", with: "Becoming a juggler desing (typo) history"
+    fill_in "Group subdomain", with: "this"
+    fill_in "Description",
+      with: "A history of the designs for the Becoming a juggler team"
+    click_button "Create group"
+  end
+
+  def then_i_see_the_group_page
+    expect(page).to have_content "Becoming a juggler desing (typo) history"
+  end
+
+  def when_i_edit_the_group
+    click_link "Change details"
+  end
+
+  def then_i_see_the_edit_group_form
+    expect(page).to have_content "Change details"
+  end
+
+  def when_i_change_the_title_and_submit_the_form
+    fill_in "Title", with: "Becoming a juggler design history"
+    click_button "Save changes"
+  end
+
+  def then_i_see_the_updated_group_page
+    expect(page).to have_content "Becoming a juggler design history"
+  end
+
+  def when_i_click_the_add_project_link
+    click_link "Add design history"
+  end
+
+  def then_i_see_the_add_project_form
+    expect(page).to have_content "Add design history"
+  end
+
+  def when_i_choose_a_project_and_submit_the_form
+    choose @project1.title, visible: false
+    click_button "Save changes"
+  end
+
+  def then_i_see_the_project_on_the_group_page
+    expect(page).to have_content @project1.title
   end
 end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Groups" do
+  it "can be created, edited, and visited" do
+    given_i_am_signed_in
+    when_i_am_on_the_projects_page
+    then_i_see_a_new_group_button
+
+    when_i_click_the_new_group_button
+    then_i_see_the_new_group_form
+  end
+
+  private
+
+  before do
+    @user = create(:user)
+    @project1 = create(:project, owner: @user, subdomain: "foo")
+    @project2 = create(:project, owner: @user, subdomain: "bar")
+  end
+
+  def given_i_am_signed_in
+    sign_in @user
+  end
+
+  def when_i_am_on_the_projects_page
+    visit projects_path
+  end
+
+  def then_i_see_a_new_group_button
+    expect(page).to have_link "New group"
+  end
+
+  def when_i_click_the_new_group_button
+    click_link "New group"
+  end
+
+  def then_i_see_the_new_group_form
+    expect(page).to have_content "New group"
+  end
+end


### PR DESCRIPTION
Groups are a further iteration to solve the user need in https://github.com/design-history/design-history/pull/500.

They allow users to group up multiple design histories under the same subdomain, in order to present them together. This is useful for teams that manage multiple services.

TODO:

- [ ] Add visibility toggle for private/public groups?
- [ ] Use checkboxes instead of radios
- [ ] Add public-facing landing page
- [ ] Tidy up commits

### Screenshots

#### Without any groups

![Screenshot 2024-01-31 at 17-32-52 Your design histories and groups - Design History](https://github.com/design-history/design-history/assets/1650875/472a17cf-218a-49fe-8d07-74b461444e95)

#### New group form

![Screenshot 2024-01-31 at 17-32-56 New group - Design History](https://github.com/design-history/design-history/assets/1650875/f2526b51-0f71-4c9c-837d-0b32f93c6073)

#### Group page

![Screenshot 2024-01-31 at 17-33-38 Becoming a juggler design history - Design History](https://github.com/design-history/design-history/assets/1650875/4cb8d8b1-f963-4df7-8932-ca4389348fc1)

#### Add design history form

![Screenshot 2024-01-31 at 17-34-47 Which design history do you want to add - Design History](https://github.com/design-history/design-history/assets/1650875/49717b72-8d3b-41a9-b187-2d3f725bb8f5)

#### Group page with design history

![Screenshot 2024-01-31 at 17-33-51 Becoming a juggler design history - Design History](https://github.com/design-history/design-history/assets/1650875/519492c7-1b4f-43db-9b09-c74047d85fb8)

#### Group listed

![Screenshot 2024-01-31 at 17-32-25 Your design histories and groups - Design History](https://github.com/design-history/design-history/assets/1650875/b9b78578-2ea0-4c7a-858e-057c18ea4b90)

#### Public landing page

TODO