### PR TITLE
Repoint the capybara dependency back to Rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development do
 end
 
 group :test do
-  gem "capybara", github: "teamcapybara/capybara", ref: "52eaece"
+  gem "capybara"
   gem "cuprite"
   gem "rspec"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/teamcapybara/capybara.git
-  revision: 52eaecea6d154b7d664b0032cd1cbcad4788fe65
-  ref: 52eaece
-  specs:
-    capybara (3.40.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.11)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -140,6 +125,15 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -522,7 +516,7 @@ DEPENDENCIES
   avo
   aws-sdk-s3
   bootsnap
-  capybara!
+  capybara
   cssbundling-rails
   cuprite
   data_migrate (= 9.4.0)


### PR DESCRIPTION
The original ref has already been released.