### PR TITLE
Add log/.keep to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 tmp
 !tmp/pids
 log
+!log/.keep
 public/assets
 public/packs
 .bundle


### PR DESCRIPTION
This ensures that the log folder isn't removed when building the Docker image.

Deploys now succeed locally.