### PR TITLE
Cancel in progress deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ jobs:
   deploy:
     name: Fly
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-group
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master


### PR DESCRIPTION
This ensures that multiple subsequent deploys don't clash into each other, and the last merged commit will win.