### PR TITLE
Bump data-migrate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "avo"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", require: false
 gem "cssbundling-rails"
-gem "data_migrate", "9.4.0"
+gem "data_migrate", "11.0.0.rc3"
 gem "devise"
 gem "faker"
 gem "friendly_id"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     cuprite (0.15.1)
       capybara (~> 3.0)
       ferrum (~> 0.15.0)
-    data_migrate (9.4.0)
+    data_migrate (11.0.0.rc3)
       activerecord (>= 6.1)
       railties (>= 6.1)
     date (3.3.4)
@@ -505,7 +505,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   cuprite
-  data_migrate (= 9.4.0)
+  data_migrate (= 11.0.0.rc3)
   debug
   devise
   dotenv-rails


### PR DESCRIPTION
9.4.x isn't compatible with Rails 7.2.