### PR TITLE
Remove .init() calls from stimulus components

### DIFF
--- a/app/javascript/controllers/govuk_accordion_controller.js
+++ b/app/javascript/controllers/govuk_accordion_controller.js
@@ -4,6 +4,6 @@ import { Accordion } from "govuk-frontend";
 // Connects to data-module="govuk-accordion"
 export default class extends Controller {
   connect() {
-    new Accordion(this.element).init();
+    new Accordion(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_button_controller.js
+++ b/app/javascript/controllers/govuk_button_controller.js
@@ -4,6 +4,6 @@ import { Button } from "govuk-frontend";
 // Connects to data-module="govuk-button"
 export default class extends Controller {
   connect() {
-    new Button(this.element).init();
+    new Button(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_character_count_controller.js
+++ b/app/javascript/controllers/govuk_character_count_controller.js
@@ -4,6 +4,6 @@ import { CharacterCount } from "govuk-frontend";
 // Connects to data-module="govuk-character-count"
 export default class extends Controller {
   connect() {
-    new CharacterCount(this.element).init();
+    new CharacterCount(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_checkboxes_controller.js
+++ b/app/javascript/controllers/govuk_checkboxes_controller.js
@@ -4,6 +4,6 @@ import { Checkboxes } from "govuk-frontend";
 // Connects to data-module="govuk-checkboxes"
 export default class extends Controller {
   connect() {
-    new Checkboxes(this.element).init();
+    new Checkboxes(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_error_summary_controller.js
+++ b/app/javascript/controllers/govuk_error_summary_controller.js
@@ -4,6 +4,6 @@ import { ErrorSummary } from "govuk-frontend";
 // Connects to data-module="govuk-error-summary"
 export default class extends Controller {
   connect() {
-    new ErrorSummary(this.element).init();
+    new ErrorSummary(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_header_controller.js
+++ b/app/javascript/controllers/govuk_header_controller.js
@@ -4,6 +4,6 @@ import { Header } from "govuk-frontend";
 // Connects to data-module="govuk-header"
 export default class extends Controller {
   connect() {
-    new Header(this.element).init();
+    new Header(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_notification_banner_controller.js
+++ b/app/javascript/controllers/govuk_notification_banner_controller.js
@@ -4,6 +4,6 @@ import { NotificationBanner } from "govuk-frontend";
 // Connects to data-module="govuk-notification-banner"
 export default class extends Controller {
   connect() {
-    new NotificationBanner(this.element).init();
+    new NotificationBanner(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_radios_controller.js
+++ b/app/javascript/controllers/govuk_radios_controller.js
@@ -4,6 +4,6 @@ import { Radios } from "govuk-frontend";
 // Connects to data-module="govuk-radios"
 export default class extends Controller {
   connect() {
-    new Radios(this.element).init();
+    new Radios(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_skip_link_controller.js
+++ b/app/javascript/controllers/govuk_skip_link_controller.js
@@ -4,6 +4,6 @@ import { SkipLink } from "govuk-frontend";
 // Connects to data-module="govuk-skip-link"
 export default class extends Controller {
   connect() {
-    new SkipLink(this.element).init();
+    new SkipLink(this.element);
   }
 }

--- a/app/javascript/controllers/govuk_tabs_controller.js
+++ b/app/javascript/controllers/govuk_tabs_controller.js
@@ -4,6 +4,6 @@ import { Tabs } from "govuk-frontend";
 // Connects to data-module="govuk-tabs"
 export default class extends Controller {
   connect() {
-    new Tabs(this.element).init();
+    new Tabs(this.element);
   }
 }


### PR DESCRIPTION
govuk-frontend removed the need to call .init.